### PR TITLE
Add GuanFu CLI and Koji RPM rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ htmlcov/
 # Documentation builds
 docs/_build/
 
+# Local rebuild output
+guanfu-koji-rebuild/
+
 # IPython
 .ipynb_checkpoints
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GitHub Action for **reproducible container-based builds**. GuanFu reads a decl
 - **Reproducible builds** — Pre-configured `SOURCE_DATE_EPOCH`, RPM macros, and Rust compiler flags for bit-for-bit reproducibility.
 - **Input management** — Download remote artifacts or mount local files into the build container, with optional SHA-256 verification.
 - **Multi-OS support** — Built-in runners for Anolis OS and Alibaba Cloud Linux, extensible to other distributions.
+- **Local CLI** — Use `guanfu` to run the existing buildspec rebuild flow or rebuild published OpenAnolis Koji RPMs locally.
 - **Release workflow** — Reusable GitHub Actions workflow with SLSA provenance generation and optional Rekor transparency log upload.
 
 ## Quick Start
@@ -68,6 +69,35 @@ outputs:
 
 See [docs/buildspec.md](docs/buildspec.md) for the full specification.
 
+### Local CLI
+
+From a source checkout:
+
+```bash
+python3 -m pip install -e .
+```
+
+Run the existing buildspec rebuild flow through the unified CLI:
+
+```bash
+guanfu rebuild buildspec --spec buildspec.yaml
+```
+
+The legacy script entry point remains supported:
+
+```bash
+./src/build-runner.sh buildspec.yaml
+```
+
+Rebuild a published OpenAnolis Koji RPM locally:
+
+```bash
+guanfu rebuild koji-rpm \
+  --rpm-name zlib-1.2.13-3.an23.x86_64.rpm
+```
+
+Koji RPM rebuild requires a Linux host with `koji`, `mock`, `rpm`, and `dnf`.
+
 ## Action Inputs
 
 | Input       | Description               | Required | Default          |
@@ -100,8 +130,10 @@ See [docs/workflow_usage_guide.md](docs/workflow_usage_guide.md) for details.
 
 ```
 ├── action.yml                  # GitHub Action definition
+├── pyproject.toml              # Python package and guanfu console script
 ├── src/
 │   ├── build-runner.sh         # Entry point — sets up Docker and mounts
+│   ├── guanfu/                 # Unified local CLI and Koji RPM rebuild modules
 │   ├── run_build.py            # Main build orchestrator (runs inside container)
 │   ├── validate_buildspec.py   # Validates buildspec paths
 │   └── os_runners/             # OS-specific package installation

--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -7,7 +7,7 @@
 在开始本地重复构建之前，请确保您已满足以下条件：
 
 1. 已安装 Docker
-2. 已安装 Python 3.7+
+2. 已安装 Python 3.6+
 3. 已安装 Git
 4. 已安装 YAML 解析器（PyYAML 包）
 
@@ -15,7 +15,7 @@
 
 GuanFu 提供了 `build-runner.sh` 脚本，默认以容器模式运行，即启动容器并在容器中运行构建。
 
-使用方式非常简单：
+为了兼容既有用法，脚本入口会继续保留：
 
 ```bash
 # 在 GuanFu 项目根目录下运行
@@ -23,6 +23,15 @@ GuanFu 提供了 `build-runner.sh` 脚本，默认以容器模式运行，即启
 ```
 
 如果未指定 `buildspec.yaml` 文件路径，则默认使用 `buildspec.yaml`。
+
+同时，GuanFu 也提供统一的 Python 命令行入口：
+
+```bash
+python3 -m pip install -e .
+guanfu rebuild buildspec --spec path/to/your/buildspec.yaml
+```
+
+`guanfu rebuild buildspec` 当前会薄包装既有 `build-runner.sh` 逻辑，因此两种方式的构建行为保持一致。
 
 脚本会：
 - 从 buildspec.yaml 文件中读取容器镜像配置
@@ -45,3 +54,31 @@ GuanFu 提供了 `build-runner.sh` 脚本，默认以容器模式运行，即启
 2. 配置默认环境参数
 3. 根据 environment 部分安装系统包和工具
 4. 执行 phases 中定义的构建阶段命令
+
+## OpenAnolis Koji RPM rebuild
+
+GuanFu 还提供本地 Koji RPM rebuild 子命令，用于验证已经发布出来的 OpenAnolis RPM：
+
+```bash
+guanfu rebuild koji-rpm \
+  --rpm-name zlib-1.2.13-3.an23.x86_64.rpm
+```
+
+该流程会：
+
+1. 根据 RPM 名称查询 OpenAnolis Koji，定位 buildroot 和构建任务
+2. 从发布 source repo 获取 SRPM，并下载 Koji task SRPM/logs 做同源校验
+3. 使用 Koji `buildroot_id` 生成 `mock.cfg`
+4. 使用 `mock --rebuild` 在本地重建发布 SRPM
+5. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
+
+默认 Koji 配置：
+
+```text
+koji server: https://build.openanolis.cn/kojihub
+koji topurl: https://build.openanolis.cn/kojifiles
+source RPM base URL: https://mirrors.openanolis.cn/anolis/23/os/source/Packages/
+binary RPM base URL: https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/
+```
+
+Koji RPM rebuild 需要 Linux 环境，并安装 `koji`、`mock`、`rpm` 和 `dnf`。macOS 不能原生运行 `mock`，需要 Linux 虚拟机或远程 Linux 主机。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "guanfu"
+version = "0.1.0"
+description = "GuanFu local rebuild tooling"
+readme = "README.md"
+requires-python = ">=3.6"
+license = { text = "Apache-2.0" }
+
+[project.scripts]
+guanfu = "guanfu.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/guanfu/__init__.py
+++ b/src/guanfu/__init__.py
@@ -1,0 +1,3 @@
+"""GuanFu local command line tools."""
+
+__version__ = "0.1.0"

--- a/src/guanfu/buildspec_rebuild.py
+++ b/src/guanfu/buildspec_rebuild.py
@@ -1,0 +1,16 @@
+import subprocess
+from pathlib import Path
+
+
+def _repo_root():
+    return Path(__file__).resolve().parents[2]
+
+
+def run_buildspec_rebuild(args):
+    build_runner = _repo_root() / "src" / "build-runner.sh"
+    if not build_runner.is_file():
+        raise SystemExit(
+            "build-runner.sh was not found. "
+            "Run this command from a GuanFu source checkout for now."
+        )
+    return subprocess.call([str(build_runner), args.spec])

--- a/src/guanfu/cli.py
+++ b/src/guanfu/cli.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+from guanfu import __version__
+from guanfu.buildspec_rebuild import run_buildspec_rebuild
+from guanfu.koji_rebuild.command import run_koji_rpm_rebuild
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="guanfu")
+    parser.add_argument("--version", action="version", version=f"guanfu {__version__}")
+
+    subparsers = parser.add_subparsers(dest="command")
+    rebuild = subparsers.add_parser("rebuild", help="Run local rebuild workflows")
+    rebuild_subparsers = rebuild.add_subparsers(dest="rebuild_command")
+
+    buildspec = rebuild_subparsers.add_parser(
+        "buildspec",
+        help="Run the existing buildspec container rebuild flow",
+    )
+    buildspec.add_argument(
+        "--spec",
+        default="buildspec.yaml",
+        help="Path to buildspec YAML file",
+    )
+    buildspec.set_defaults(func=run_buildspec_rebuild)
+
+    koji = rebuild_subparsers.add_parser(
+        "koji-rpm",
+        help="Rebuild an RPM produced by a Koji instance",
+    )
+    source = koji.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--rpm-name",
+        help="Published RPM filename, for example zlib-1.2.13-3.an23.x86_64.rpm",
+    )
+    source.add_argument(
+        "--slsa-provenance",
+        help="RPM SLSA provenance file. Reserved for the second implementation phase.",
+    )
+    koji.add_argument(
+        "--koji-server",
+        default="https://build.openanolis.cn/kojihub",
+        help="Koji XML-RPC hub URL",
+    )
+    koji.add_argument(
+        "--koji-topurl",
+        default="https://build.openanolis.cn/kojifiles",
+        help="Koji topurl for repos and mock-config",
+    )
+    koji.add_argument(
+        "--binary-rpm-base-url",
+        default="https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/",
+        help="Base URL for published binary RPMs",
+    )
+    koji.add_argument(
+        "--source-rpm-base-url",
+        default="https://mirrors.openanolis.cn/anolis/23/os/source/Packages/",
+        help="Base URL for published source RPMs",
+    )
+    koji.add_argument(
+        "--workdir",
+        default="guanfu-koji-rebuild",
+        help="Directory for downloaded inputs, mock config, rebuild results, and reports",
+    )
+    koji.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="Number of local rebuild runs",
+    )
+    koji.add_argument(
+        "--isolation",
+        default="simple",
+        help="mock isolation mode",
+    )
+    koji.set_defaults(func=run_koji_rpm_rebuild)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help(sys.stderr)
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/guanfu/koji_rebuild/__init__.py
+++ b/src/guanfu/koji_rebuild/__init__.py
@@ -1,0 +1,1 @@
+"""Koji RPM rebuild implementation."""

--- a/src/guanfu/koji_rebuild/client.py
+++ b/src/guanfu/koji_rebuild/client.py
@@ -1,0 +1,28 @@
+import xmlrpc.client
+
+
+class KojiClient:
+    def __init__(self, server_url):
+        self.server_url = server_url
+        self.session = xmlrpc.client.ServerProxy(server_url, allow_none=True)
+
+    def get_rpm(self, rpm_info):
+        return self.session.getRPM(rpm_info, True, False)
+
+    def get_build(self, build_id):
+        return self.session.getBuild(build_id, True)
+
+    def get_buildroot(self, buildroot_id):
+        return self.session.getBuildroot(buildroot_id, True)
+
+    def get_task_children(self, task_id):
+        return self.session.getTaskChildren(task_id)
+
+    def get_task_result(self, task_id):
+        return self.session.getTaskResult(task_id, False)
+
+    def list_task_output(self, task_id):
+        return self.session.listTaskOutput(task_id, True)
+
+    def download_task_output(self, task_id, filename, offset, size):
+        return self.session.downloadTaskOutput(task_id, filename, offset, size)

--- a/src/guanfu/koji_rebuild/command.py
+++ b/src/guanfu/koji_rebuild/command.py
@@ -1,0 +1,204 @@
+import re
+import sys
+import time
+from pathlib import Path
+
+from guanfu.koji_rebuild.client import KojiClient
+from guanfu.koji_rebuild.compare import compare_published_and_rebuilt, compare_srpms
+from guanfu.koji_rebuild.downloader import (
+    download_task_output,
+    join_url,
+    summarize_file,
+    try_download_url,
+)
+from guanfu.koji_rebuild.mock_config import generate_mock_config, probe_repodata
+from guanfu.koji_rebuild.mock_runner import run_rebuild
+from guanfu.koji_rebuild.report import write_json
+from guanfu.koji_rebuild.resolver import resolve_koji_build
+from guanfu.koji_rebuild.rpm_name import parse_rpm_filename, rpm_filename
+
+
+def _safe_name(name):
+    return re.sub(r"[^A-Za-z0-9_.+-]+", "_", name)
+
+
+def _run_dir(workdir, rpm_name):
+    base = Path(workdir) / _safe_name(Path(rpm_name).name)
+    if not base.exists() or not any(base.iterdir()):
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+    timestamp = time.strftime("run-%Y%m%d%H%M%S")
+    path = base / timestamp
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _download_koji_logs(client, task_id, outputs, inputs_dir):
+    downloads = []
+    for log_name in ("build.log", "root.log", "installed_pkgs.log", "mock_output.log"):
+        if log_name in outputs:
+            path = download_task_output(client, task_id, log_name, inputs_dir / log_name)
+            downloads.append(summarize_file(path, label="koji_task_log"))
+    return downloads
+
+
+def _download_task_srpm(client, task_id, srpm_name, inputs_dir):
+    path = download_task_output(client, task_id, srpm_name, inputs_dir / f"koji-task-{srpm_name}")
+    return path, summarize_file(path, label="koji_task_srpm")
+
+
+def _download_published(url, dest, label):
+    path, error = try_download_url(url, dest)
+    if error:
+        return None, {"label": label, "url": url, "error": error}
+    return path, summarize_file(path, label=label, url=url)
+
+
+def run_koji_rpm_rebuild(args):
+    if args.slsa_provenance:
+        print(
+            "RPM SLSA provenance input is reserved but not implemented yet. "
+            "Please use --rpm-name for Koji RPM rebuild.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.runs < 1:
+        print("--runs must be >= 1", file=sys.stderr)
+        return 2
+
+    run_dir = _run_dir(args.workdir, args.rpm_name)
+    inputs_dir = run_dir / "inputs"
+    results_dir = run_dir / "results"
+    metadata_dir = run_dir / "metadata"
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "input": {
+            "rpm_name": args.rpm_name,
+            "koji_server": args.koji_server,
+            "koji_topurl": args.koji_topurl,
+            "binary_rpm_base_url": args.binary_rpm_base_url,
+            "source_rpm_base_url": args.source_rpm_base_url,
+            "runs": args.runs,
+            "isolation": args.isolation,
+        },
+        "workdir": str(run_dir),
+    }
+
+    try:
+        rpm_info = parse_rpm_filename(args.rpm_name)
+        client = KojiClient(args.koji_server)
+        resolution = resolve_koji_build(client, rpm_info)
+        target_rpm_name = rpm_filename(resolution.rpm)
+
+        write_json(metadata_dir / "rpm.json", resolution.rpm)
+        write_json(metadata_dir / "build.json", resolution.build)
+        write_json(metadata_dir / "buildroot.json", resolution.buildroot)
+        write_json(metadata_dir / "buildarch-task.json", resolution.buildarch_task)
+        write_json(metadata_dir / "task-result.json", resolution.task_result)
+
+        repo_probe = probe_repodata(args.koji_topurl, resolution.buildroot)
+        report["repo_probe"] = repo_probe
+        write_json(metadata_dir / "repo-probe.json", repo_probe)
+        if repo_probe.get("status") != 200:
+            report["status"] = "skipped"
+            report["reason"] = "original buildroot repo repomd.xml is not available"
+            write_json(run_dir / "report.json", report)
+            print(f"[guanfu] Historical repo is not available: {repo_probe.get('url')}", file=sys.stderr)
+            return 3
+
+        published_rpm_url = join_url(args.binary_rpm_base_url, target_rpm_name)
+        published_rpm, published_rpm_summary = _download_published(
+            published_rpm_url,
+            inputs_dir / target_rpm_name,
+            "published_rpm",
+        )
+        if not published_rpm:
+            raise RuntimeError(f"failed to download published RPM: {published_rpm_summary}")
+
+        published_srpm_url = join_url(args.source_rpm_base_url, resolution.task_srpm_name)
+        published_srpm, published_srpm_summary = _download_published(
+            published_srpm_url,
+            inputs_dir / resolution.task_srpm_name,
+            "published_srpm",
+        )
+
+        task_srpm, task_srpm_summary = _download_task_srpm(
+            client,
+            resolution.buildarch_task["id"],
+            resolution.task_srpm_name,
+            inputs_dir,
+        )
+        log_summaries = _download_koji_logs(
+            client,
+            resolution.buildarch_task["id"],
+            resolution.outputs,
+            inputs_dir,
+        )
+
+        downloads = [published_rpm_summary, task_srpm_summary] + log_summaries
+        if published_srpm_summary:
+            downloads.insert(1, published_srpm_summary)
+        report["downloads"] = downloads
+
+        srpm_for_rebuild = published_srpm
+        report["srpm_source"] = "openanolis_source_mirror"
+        report["srpm_is_published_artifact"] = True
+        if not srpm_for_rebuild:
+            srpm_for_rebuild = task_srpm
+            report["srpm_source"] = "koji_task_fallback"
+            report["srpm_is_published_artifact"] = False
+
+        report["srpm_cross_check"] = compare_srpms(published_srpm, task_srpm)
+
+        mock_cfg = inputs_dir / "mock.cfg"
+        generate_mock_config(
+            args.koji_server,
+            args.koji_topurl,
+            resolution.buildroot["id"],
+            mock_cfg,
+        )
+        report["mock_config"] = {
+            "file": str(mock_cfg),
+            "buildroot_id": resolution.buildroot["id"],
+        }
+
+        rebuilds = []
+        for run_index in range(1, args.runs + 1):
+            resultdir = results_dir / f"result-run-{run_index}"
+            result = run_rebuild(mock_cfg, srpm_for_rebuild, resultdir, isolation=args.isolation)
+            result["run"] = run_index
+            rebuilds.append(result)
+            if result["exit_code"] != 0:
+                break
+        report["rebuilds"] = rebuilds
+
+        successful = rebuilds and all(item["exit_code"] == 0 for item in rebuilds)
+        report["status"] = "rebuilt" if successful else "failed"
+        if successful:
+            first_run_rpms = [Path(item.get("path", item["file"])) for item in rebuilds[0]["rpms"]]
+            report["comparison"] = compare_published_and_rebuilt(
+                published_rpm,
+                first_run_rpms,
+                target_rpm_name,
+            )
+            if len(rebuilds) > 1:
+                first = [(rpm["file"], rpm["sha256"]) for rpm in rebuilds[0]["rpms"]]
+                report["repeatable_by_rpm_sha256"] = all(
+                    [(rpm["file"], rpm["sha256"]) for rpm in rebuild["rpms"]] == first
+                    for rebuild in rebuilds[1:]
+                )
+
+        write_json(run_dir / "report.json", report)
+        print(f"[guanfu] Koji RPM rebuild report: {run_dir / 'report.json'}")
+        return 0 if successful else 1
+    except Exception as exc:
+        report["status"] = "error"
+        report["error"] = repr(exc)
+        write_json(run_dir / "report.json", report)
+        print(f"[guanfu] ERROR: {exc}", file=sys.stderr)
+        print(f"[guanfu] Partial report: {run_dir / 'report.json'}", file=sys.stderr)
+        return 1

--- a/src/guanfu/koji_rebuild/compare.py
+++ b/src/guanfu/koji_rebuild/compare.py
@@ -1,0 +1,107 @@
+import subprocess
+from pathlib import Path
+
+from guanfu.koji_rebuild.downloader import sha256_file
+
+
+def _run_text(cmd):
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    if proc.returncode != 0:
+        return None, proc.stderr.strip()
+    return proc.stdout, None
+
+
+def _rpm_query(path):
+    query = (
+        "NVRA=%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\\n"
+        "BUILDTIME=%{BUILDTIME}\\n"
+        "BUILDHOST=%{BUILDHOST}\\n"
+        "SOURCERPM=%{SOURCERPM}\\n"
+        "PAYLOADDIGEST=%{PAYLOADDIGEST}\\n"
+        "SIGMD5=%{SIGMD5}\\n"
+        "SHA256HEADER=%{SHA256HEADER}\\n"
+    )
+    out, err = _run_text(["rpm", "-qp", "--qf", query, str(path)])
+    if err:
+        return {"error": err}
+    result = {}
+    for line in out.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            result[key] = value
+    return result
+
+
+def _rpm_command_lines(path, option):
+    out, err = _run_text(["rpm", "-qp", option, str(path)])
+    if err:
+        return {"error": err}
+    return sorted(out.splitlines())
+
+
+def _rpm_dump(path):
+    out, err = _run_text(["rpm", "-qp", "--dump", str(path)])
+    if err:
+        return {"error": err}
+    return sorted(out.splitlines())
+
+
+def _find_rebuilt_rpm(result_rpms, target_filename):
+    for rpm in result_rpms:
+        if Path(rpm).name == target_filename:
+            return Path(rpm)
+    return None
+
+
+def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename):
+    published = Path(published_rpm)
+    rebuilt = _find_rebuilt_rpm(result_rpms, target_filename)
+    if not rebuilt:
+        return {
+            "status": "missing_rebuilt_target_rpm",
+            "target_filename": target_filename,
+        }
+
+    published_requires = _rpm_command_lines(published, "--requires")
+    rebuilt_requires = _rpm_command_lines(rebuilt, "--requires")
+    published_provides = _rpm_command_lines(published, "--provides")
+    rebuilt_provides = _rpm_command_lines(rebuilt, "--provides")
+    published_scripts = _rpm_command_lines(published, "--scripts")
+    rebuilt_scripts = _rpm_command_lines(rebuilt, "--scripts")
+    published_dump = _rpm_dump(published)
+    rebuilt_dump = _rpm_dump(rebuilt)
+
+    return {
+        "status": "compared",
+        "target_filename": target_filename,
+        "published": {
+            "file": str(published),
+            "sha256": sha256_file(published),
+            "headers": _rpm_query(published),
+        },
+        "rebuilt": {
+            "file": str(rebuilt),
+            "sha256": sha256_file(rebuilt),
+            "headers": _rpm_query(rebuilt),
+        },
+        "rpm_file_sha256_equal": sha256_file(published) == sha256_file(rebuilt),
+        "requires_equal": published_requires == rebuilt_requires,
+        "provides_equal": published_provides == rebuilt_provides,
+        "scripts_equal": published_scripts == rebuilt_scripts,
+        "dump_equal": published_dump == rebuilt_dump,
+    }
+
+
+def compare_srpms(published_srpm, task_srpm):
+    if not published_srpm or not task_srpm:
+        return {"status": "skipped"}
+    published = Path(published_srpm)
+    task = Path(task_srpm)
+    return {
+        "status": "compared",
+        "published_srpm_sha256": sha256_file(published),
+        "koji_task_srpm_sha256": sha256_file(task),
+        "file_sha256_equal": sha256_file(published) == sha256_file(task),
+        "published_headers": _rpm_query(published),
+        "koji_task_headers": _rpm_query(task),
+    }

--- a/src/guanfu/koji_rebuild/downloader.py
+++ b/src/guanfu/koji_rebuild/downloader.py
@@ -1,0 +1,87 @@
+import base64
+import hashlib
+import urllib.error
+import urllib.parse
+import urllib.request
+import xmlrpc.client
+from pathlib import Path
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def summarize_file(path, label=None, url=None):
+    path = Path(path)
+    summary = {
+        "file": path.name,
+        "path": str(path),
+        "size": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+    if label:
+        summary["label"] = label
+    if url:
+        summary["url"] = url
+    return summary
+
+
+def join_url(base_url, filename):
+    if not base_url.endswith("/"):
+        base_url += "/"
+    return urllib.parse.urljoin(base_url, urllib.parse.quote(filename))
+
+
+def download_url(url, dest):
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(url, headers={"User-Agent": "guanfu-koji-rebuild/0.1"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        with open(dest, "wb") as f:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
+    return dest
+
+
+def try_download_url(url, dest):
+    try:
+        return download_url(url, dest), None
+    except urllib.error.HTTPError as exc:
+        return None, f"HTTP {exc.code}: {exc.reason}"
+    except Exception as exc:
+        return None, repr(exc)
+
+
+def _decode_xmlrpc_chunk(chunk):
+    if isinstance(chunk, xmlrpc.client.Binary):
+        return chunk.data
+    if isinstance(chunk, bytes):
+        return chunk
+    if isinstance(chunk, str):
+        return base64.b64decode(chunk)
+    raise TypeError(f"unexpected download chunk type: {type(chunk)!r}")
+
+
+def download_task_output(client, task_id, filename, dest):
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    offset = 0
+    size = 1024 * 1024
+    with open(dest, "wb") as f:
+        while True:
+            chunk = client.download_task_output(task_id, filename, offset, size)
+            data = _decode_xmlrpc_chunk(chunk)
+            if not data:
+                break
+            f.write(data)
+            offset += len(data)
+            if len(data) < size:
+                break
+    return dest

--- a/src/guanfu/koji_rebuild/mock_config.py
+++ b/src/guanfu/koji_rebuild/mock_config.py
@@ -1,0 +1,42 @@
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def historical_repo_url(koji_topurl, buildroot):
+    topurl = koji_topurl.rstrip("/")
+    return (
+        f"{topurl}/repos/{buildroot['tag_name']}/"
+        f"{buildroot['repo_id']}/{buildroot['arch']}"
+    )
+
+
+def probe_repodata(koji_topurl, buildroot):
+    repo_url = historical_repo_url(koji_topurl, buildroot)
+    repomd_url = f"{repo_url}/repodata/repomd.xml"
+    try:
+        request = urllib.request.Request(repomd_url, method="GET")
+        with urllib.request.urlopen(request, timeout=20) as response:
+            response.read(64)
+            return {"url": repomd_url, "status": response.status}
+    except urllib.error.HTTPError as exc:
+        return {"url": repomd_url, "status": exc.code, "error": str(exc)}
+    except Exception as exc:
+        return {"url": repomd_url, "status": None, "error": repr(exc)}
+
+
+def generate_mock_config(koji_server, koji_topurl, buildroot_id, dest):
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "koji",
+        f"--server={koji_server}",
+        "mock-config",
+        f"--buildroot={buildroot_id}",
+        f"--topurl={koji_topurl}",
+        "-o",
+        str(dest),
+    ]
+    subprocess.run(cmd, check=True)
+    return dest

--- a/src/guanfu/koji_rebuild/mock_runner.py
+++ b/src/guanfu/koji_rebuild/mock_runner.py
@@ -1,0 +1,33 @@
+import subprocess
+import time
+from pathlib import Path
+
+from guanfu.koji_rebuild.downloader import summarize_file
+
+
+def _list_result_rpms(resultdir):
+    return sorted(Path(resultdir).glob("*.rpm"))
+
+
+def run_rebuild(mock_cfg, srpm, resultdir, isolation="simple"):
+    resultdir = Path(resultdir)
+    resultdir.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    cmd = [
+        "mock",
+        "-r",
+        str(mock_cfg),
+        f"--isolation={isolation}",
+        "--resultdir",
+        str(resultdir),
+        "--rebuild",
+        str(srpm),
+    ]
+    proc = subprocess.run(cmd)
+    elapsed = time.time() - started
+    return {
+        "exit_code": proc.returncode,
+        "elapsed_seconds": round(elapsed, 1),
+        "command": cmd,
+        "rpms": [summarize_file(path) for path in _list_result_rpms(resultdir)],
+    }

--- a/src/guanfu/koji_rebuild/report.py
+++ b/src/guanfu/koji_rebuild/report.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+
+def write_json(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/src/guanfu/koji_rebuild/resolver.py
+++ b/src/guanfu/koji_rebuild/resolver.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+
+class KojiResolution:
+    def __init__(self, rpm, build, buildroot, buildarch_task, task_result, outputs, task_srpm_name):
+        self.rpm = rpm
+        self.build = build
+        self.buildroot = buildroot
+        self.buildarch_task = buildarch_task
+        self.task_result = task_result
+        self.outputs = outputs
+        self.task_srpm_name = task_srpm_name
+
+
+def _select_buildarch_task(client, build_task_id, arch, buildroot_id):
+    children = client.get_task_children(build_task_id)
+    candidates = [
+        child
+        for child in children
+        if child.get("method") == "buildArch" and child.get("arch") == arch
+    ]
+    for child in candidates:
+        try:
+            result = client.get_task_result(child["id"])
+        except Exception:
+            continue
+        if result and result.get("brootid") == buildroot_id:
+            return child
+    if candidates:
+        return candidates[0]
+    raise RuntimeError(f"no buildArch task for arch={arch} under task={build_task_id}")
+
+
+def _select_task_srpm(task_result, outputs):
+    srpms = [Path(path).name for path in task_result.get("srpms", [])]
+    if not srpms:
+        srpms = [name for name in outputs if name.endswith(".src.rpm")]
+    if not srpms:
+        raise RuntimeError("no src.rpm found in buildArch task output")
+    return sorted(srpms)[0]
+
+
+def resolve_koji_build(client, rpm_info):
+    rpm = client.get_rpm(rpm_info)
+    if not rpm:
+        raise RuntimeError(f"RPM was not found in Koji: {rpm_info}")
+
+    build = client.get_build(rpm["build_id"])
+    buildroot = client.get_buildroot(rpm["buildroot_id"])
+    buildarch = _select_buildarch_task(
+        client,
+        build["task_id"],
+        buildroot["arch"],
+        rpm.get("buildroot_id"),
+    )
+    task_result = client.get_task_result(buildarch["id"])
+    outputs = client.list_task_output(buildarch["id"])
+    task_srpm_name = _select_task_srpm(task_result, outputs)
+
+    return KojiResolution(
+        rpm=rpm,
+        build=build,
+        buildroot=buildroot,
+        buildarch_task=buildarch,
+        task_result=task_result,
+        outputs=outputs,
+        task_srpm_name=task_srpm_name,
+    )

--- a/src/guanfu/koji_rebuild/rpm_name.py
+++ b/src/guanfu/koji_rebuild/rpm_name.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+def parse_rpm_filename(filename):
+    rpm_name = Path(filename).name
+    if not rpm_name.endswith(".rpm"):
+        raise ValueError(f"RPM filename must end with .rpm: {filename}")
+    stem = rpm_name[:-4]
+    try:
+        nvr, arch = stem.rsplit(".", 1)
+        nv, release = nvr.rsplit("-", 1)
+        name, version = nv.rsplit("-", 1)
+    except ValueError as exc:
+        raise ValueError(f"Cannot parse RPM filename as name-version-release.arch.rpm: {filename}") from exc
+    if not all([name, version, release, arch]):
+        raise ValueError(f"Cannot parse RPM filename as name-version-release.arch.rpm: {filename}")
+    return {
+        "name": name,
+        "version": version,
+        "release": release,
+        "arch": arch,
+    }
+
+
+def rpm_filename(rpm):
+    return f"{rpm['name']}-{rpm['version']}-{rpm['release']}.{rpm['arch']}.rpm"


### PR DESCRIPTION
## Summary
- add a Python `guanfu` CLI with `rebuild buildspec` and `rebuild koji-rpm` subcommands
- implement first-phase OpenAnolis Koji RPM rebuild from a published RPM name
- download published SRPM/RPM, cross-check Koji task SRPM/logs, generate mock config, run mock rebuild, and write `report.json`
- document the new local CLI while preserving the legacy `build-runner.sh` entrypoint

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m guanfu.cli --version`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m guanfu.cli rebuild koji-rpm --help`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m guanfu.cli rebuild koji-rpm --slsa-provenance /tmp/example.intoto.jsonl` returns the reserved second-phase error
- remote Linux smoke test on Python 3.6.8 rebuilt `anolis-release-23.4-14.an23.x86_64.rpm` and produced `report.json`