### PR TITLE
Add RPM rebuild difference summary

### DIFF
--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -77,7 +77,10 @@ guanfu rebuild koji-rpm \
 - RPM header 字段差异，例如 `BUILDTIME`、`BUILDHOST`、`PAYLOADDIGEST`、`RSAHEADER`
 - 文件清单差异，例如只存在于发布 RPM 或 rebuild RPM 的文件
 - 文件属性差异，例如 `mtime`、`digest`、`size`、`mode`、owner/group
-- 汇总判断，例如是否仅有 mtime 差异、是否存在内容相关差异
+- 差异分类，例如 `RPM_SIGNATURE`、`RPM_METADATA`、`FILE_TIMESTAMP`、`FILE_PERMISSION`、`FILE_ADDED`、`FILE_REMOVED`、`SYMLINK_TARGET`、`DOC_CONTENT`、`CONFIG_CONTENT`、`SCRIPT_CONTENT`、`COMPRESSION`、`DEBUG_INFO`、`OTHER`
+- 汇总判断，例如 `risk_level`、`trust_level`、`reproducible`、`diff_by_risk_level`
+
+当前默认使用 `light` 分析模式。该模式只依赖 RPM header、RPM 文件清单、scriptlet 和路径规则，不会解包并解析 ELF section 或 BuildID。因此，当可执行文件或动态库内容发生变化时，报告会保守输出 `OTHER`，并通过 `possible_diff_types` 标记可能属于 `BINARY_CODE`、`BINARY_BUILDID` 或 `DEBUG_INFO`，同时将 `analysis_status` 标记为 `needs_deep_analysis`。
 
 默认 Koji 配置：
 

--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -78,9 +78,17 @@ guanfu rebuild koji-rpm \
 - 文件清单差异，例如只存在于发布 RPM 或 rebuild RPM 的文件
 - 文件属性差异，例如 `mtime`、`digest`、`size`、`mode`、owner/group
 - 差异分类，例如 `RPM_SIGNATURE`、`RPM_METADATA`、`FILE_TIMESTAMP`、`FILE_PERMISSION`、`FILE_ADDED`、`FILE_REMOVED`、`SYMLINK_TARGET`、`DOC_CONTENT`、`CONFIG_CONTENT`、`SCRIPT_CONTENT`、`COMPRESSION`、`DEBUG_INFO`、`OTHER`
-- 汇总判断，例如 `risk_level`、`trust_level`、`reproducible`、`diff_by_risk_level`
+- 汇总判断，例如 `risk_level`、`action`、`reproducible`、`confidence`、`trust_level`、`diff_by_risk_level`
 
-当前默认使用 `light` 分析模式。该模式只依赖 RPM header、RPM 文件清单、scriptlet 和路径规则，不会解包并解析 ELF section 或 BuildID。因此，当可执行文件或动态库内容发生变化时，报告会保守输出 `OTHER`，并通过 `possible_diff_types` 标记可能属于 `BINARY_CODE`、`BINARY_BUILDID` 或 `DEBUG_INFO`，同时将 `analysis_status` 标记为 `needs_deep_analysis`。
+当前默认使用 `light` 分析模式。该模式只依赖 RPM header、RPM 文件清单、scriptlet 和路径规则，不会解包并解析 ELF section 或 BuildID。因此，当可执行文件或动态库内容发生变化时，报告会保守输出 `OTHER`，并通过 `possible_diff_types` 标记可能属于 `BINARY_CODE`、`BINARY_BUILDID` 或 `DEBUG_INFO`。默认报告不包含原始 header/file diff，原始 Koji 元数据会保存在本次运行目录的 `metadata/` 下。
+
+`trust_level` 映射为：
+
+- `L4`: 发布 RPM 与本地 rebuild RPM 字节级一致
+- `L3`: 只有时间戳、签名、BuildID 等预期构建环境差异
+- `L2`: 差异均可解释，且没有安全相关异常
+- `L1`: 存在少量非预期差异，但没有安全风险迹象
+- `L0`: 存在不可解释差异或安全相关异常
 
 默认 Koji 配置：
 

--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -72,6 +72,13 @@ guanfu rebuild koji-rpm \
 4. 使用 `mock --rebuild` 在本地重建发布 SRPM
 5. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
 
+`report.json` 会包含轻量差异摘要：
+
+- RPM header 字段差异，例如 `BUILDTIME`、`BUILDHOST`、`PAYLOADDIGEST`、`RSAHEADER`
+- 文件清单差异，例如只存在于发布 RPM 或 rebuild RPM 的文件
+- 文件属性差异，例如 `mtime`、`digest`、`size`、`mode`、owner/group
+- 汇总判断，例如是否仅有 mtime 差异、是否存在内容相关差异
+
 默认 Koji 配置：
 
 ```text

--- a/src/guanfu/koji_rebuild/assessment.py
+++ b/src/guanfu/koji_rebuild/assessment.py
@@ -1,0 +1,630 @@
+MAX_AFFECTED_FILES = 20
+ASSESSMENT_VERSION = "1.0.0"
+
+RISK_LEVELS = ["none", "low", "medium", "high", "critical"]
+RISK_VALUES = dict((level, index) for index, level in enumerate(RISK_LEVELS))
+
+HEADER_SIGNATURE_FIELDS = set(["RSAHEADER", "SIGPGP", "SIGGPG", "DSAHEADER"])
+HEADER_METADATA_FIELDS = set([
+    "BUILDTIME",
+    "BUILDHOST",
+    "RPMVERSION",
+    "SIGMD5",
+    "SHA256HEADER",
+    "PAYLOADDIGEST",
+])
+HEADER_COMPRESSION_FIELDS = set(["PAYLOADCOMPRESSOR", "PAYLOADFLAGS"])
+HEADER_IDENTITY_FIELDS = set(["NVRA", "SOURCERPM", "SIZE"])
+
+UNSUPPORTED_PRECISE_TYPES = ["BINARY_CODE", "BINARY_BUILDID"]
+
+SENSITIVE_PATH_PREFIXES = (
+    "/bin/",
+    "/sbin/",
+    "/usr/bin/",
+    "/usr/sbin/",
+    "/usr/lib/systemd/",
+    "/usr/lib64/systemd/",
+    "/etc/systemd/",
+    "/etc/cron",
+    "/etc/pam.d/",
+)
+HIGHLY_SENSITIVE_PATHS = (
+    "/etc/ld.so.preload",
+    "/etc/profile",
+    "/etc/sudoers",
+)
+
+DOC_PATH_PREFIXES = (
+    "/usr/share/doc/",
+    "/usr/share/info/",
+    "/usr/share/licenses/",
+    "/usr/share/man/",
+)
+DEBUG_PATH_PREFIXES = (
+    "/usr/lib/debug/",
+    "/usr/lib64/debug/",
+)
+SCRIPT_EXTENSIONS = (
+    ".bash",
+    ".csh",
+    ".fish",
+    ".ksh",
+    ".lua",
+    ".pl",
+    ".py",
+    ".rb",
+    ".sh",
+    ".zsh",
+)
+COMPRESSED_EXTENSIONS = (
+    ".bz2",
+    ".gz",
+    ".lzma",
+    ".xz",
+    ".zst",
+    ".zip",
+)
+
+
+def _risk_at_least(left, right):
+    if RISK_VALUES[left] >= RISK_VALUES[right]:
+        return left
+    return right
+
+
+def _highest_risk(items):
+    risk = "none"
+    for item in items:
+        risk = _risk_at_least(item.get("risk_level", "none"), risk)
+    return risk
+
+
+def _limited_files(paths):
+    paths = sorted(set(paths))
+    return paths[:MAX_AFFECTED_FILES], len(paths) > MAX_AFFECTED_FILES
+
+
+def _new_diff_item(
+    diff_type,
+    risk_level,
+    description,
+    affected_files=None,
+    fields=None,
+    analysis_status="analyzed",
+    confidence=0.9,
+    possible_diff_types=None,
+):
+    item = {
+        "diff_type": diff_type,
+        "risk_level": risk_level,
+        "analysis_status": analysis_status,
+        "confidence": confidence,
+        "description": description,
+    }
+    if fields:
+        item["fields"] = sorted(fields)
+    if affected_files:
+        limited, truncated = _limited_files(affected_files)
+        item["affected_files"] = limited
+        item["affected_file_count"] = len(set(affected_files))
+        item["affected_files_truncated"] = truncated
+    if possible_diff_types:
+        item["possible_diff_types"] = possible_diff_types
+    return item
+
+
+def _is_buildid_path(path):
+    return "/.build-id/" in path or path.endswith("/.build-id")
+
+
+def _is_doc_path(path, item=None):
+    if item and item.get("isdoc") == "1":
+        return True
+    return path.startswith(DOC_PATH_PREFIXES)
+
+
+def _is_config_path(path, item=None):
+    if item and item.get("isconfig") == "1":
+        return True
+    return path.startswith("/etc/")
+
+
+def _is_debug_path(path):
+    return (
+        path.startswith(DEBUG_PATH_PREFIXES)
+        or "/.debug/" in path
+        or path.endswith(".debug")
+        or ".gnu_debug" in path
+    )
+
+
+def _is_script_path(path):
+    return (
+        path.endswith(SCRIPT_EXTENSIONS)
+        or path.startswith("/etc/init.d/")
+        or path.startswith("/etc/profile.d/")
+    )
+
+
+def _is_compressed_path(path):
+    return path.endswith(COMPRESSED_EXTENSIONS)
+
+
+def _is_sensitive_path(path):
+    return path.startswith(SENSITIVE_PATH_PREFIXES) or path in HIGHLY_SENSITIVE_PATHS
+
+
+def _mode_int(value):
+    try:
+        return int(str(value), 8)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _has_exec_bit(item):
+    return bool(_mode_int(item.get("mode")) & 0o111)
+
+
+def _has_special_exec_bit(item):
+    return bool(_mode_int(item.get("mode")) & 0o6000)
+
+
+def _is_binary_candidate(path, published, rebuilt):
+    if _is_doc_path(path, published) or _is_doc_path(path, rebuilt):
+        return False
+    if _is_config_path(path, published) or _is_config_path(path, rebuilt):
+        return False
+    if _is_debug_path(path) or _is_script_path(path):
+        return False
+    if _has_exec_bit(published) or _has_exec_bit(rebuilt):
+        return True
+    library_prefixes = ("/lib/", "/lib64/", "/usr/lib/", "/usr/lib64/")
+    return path.startswith(library_prefixes) and (
+        ".so" in path or path.endswith((".a", ".o"))
+    )
+
+
+def _path_risk(paths, default_risk="medium"):
+    risk = default_risk
+    for path in paths:
+        if path in HIGHLY_SENSITIVE_PATHS:
+            risk = _risk_at_least("critical", risk)
+        elif _is_sensitive_path(path):
+            risk = _risk_at_least("high", risk)
+    return risk
+
+
+def _permission_risk(entries):
+    risk = "low"
+    for entry in entries:
+        if _has_special_exec_bit(entry["rebuilt"]) and not _has_special_exec_bit(entry["published"]):
+            return "critical"
+        if _has_special_exec_bit(entry["published"]) or _has_special_exec_bit(entry["rebuilt"]):
+            risk = _risk_at_least("high", risk)
+        elif _is_sensitive_path(entry["path"]):
+            risk = _risk_at_least("medium", risk)
+    return risk
+
+
+def _classify_header_differences(header_diff):
+    if not header_diff or not header_diff.get("different"):
+        return []
+
+    fields = set(header_diff.get("fields", {}))
+    items = []
+    signature_fields = fields & HEADER_SIGNATURE_FIELDS
+    metadata_fields = fields & HEADER_METADATA_FIELDS
+    compression_fields = fields & HEADER_COMPRESSION_FIELDS
+    identity_fields = fields & HEADER_IDENTITY_FIELDS
+    known_fields = (
+        HEADER_SIGNATURE_FIELDS
+        | HEADER_METADATA_FIELDS
+        | HEADER_COMPRESSION_FIELDS
+        | HEADER_IDENTITY_FIELDS
+    )
+    other_fields = fields - known_fields
+
+    if signature_fields:
+        items.append(_new_diff_item(
+            "RPM_SIGNATURE",
+            "low",
+            "RPM signature-related header fields differ.",
+            fields=signature_fields,
+            confidence=0.95,
+        ))
+    if metadata_fields:
+        items.append(_new_diff_item(
+            "RPM_METADATA",
+            "low",
+            "RPM build metadata or wrapper digests differ.",
+            fields=metadata_fields,
+            confidence=0.9,
+        ))
+    if compression_fields:
+        items.append(_new_diff_item(
+            "COMPRESSION",
+            "none",
+            "RPM payload compression settings differ.",
+            fields=compression_fields,
+            confidence=0.9,
+        ))
+    if identity_fields:
+        items.append(_new_diff_item(
+            "OTHER",
+            "medium",
+            "RPM identity or package size header fields differ.",
+            fields=identity_fields,
+            analysis_status="needs_review",
+            confidence=0.7,
+        ))
+    if other_fields:
+        items.append(_new_diff_item(
+            "OTHER",
+            "medium",
+            "Unclassified RPM header fields differ.",
+            fields=other_fields,
+            analysis_status="needs_review",
+            confidence=0.65,
+        ))
+    return items
+
+
+def _classify_file_differences(files_diff, file_analysis):
+    if not files_diff or files_diff.get("status") != "compared":
+        return [_new_diff_item(
+            "OTHER",
+            "high",
+            "RPM file manifest comparison failed.",
+            analysis_status="needs_review",
+            confidence=0.5,
+        )]
+
+    if not file_analysis:
+        return []
+
+    items = []
+    only_in_published = file_analysis["only_in_published"]
+    only_in_rebuilt = file_analysis["only_in_rebuilt"]
+    buildid_added = [path for path in only_in_rebuilt if _is_buildid_path(path)]
+    buildid_removed = [path for path in only_in_published if _is_buildid_path(path)]
+    added = [path for path in only_in_rebuilt if not _is_buildid_path(path)]
+    removed = [path for path in only_in_published if not _is_buildid_path(path)]
+
+    if buildid_added or buildid_removed:
+        items.append(_new_diff_item(
+            "BUILDID_SYMLINK",
+            "none",
+            ".build-id symlink entries were added or removed.",
+            affected_files=buildid_added + buildid_removed,
+            confidence=0.85,
+        ))
+    if added:
+        items.append(_new_diff_item(
+            "FILE_ADDED",
+            _path_risk(added, "medium"),
+            "Files exist only in the rebuilt RPM.",
+            affected_files=added,
+            analysis_status="needs_review",
+            confidence=0.75,
+        ))
+    if removed:
+        items.append(_new_diff_item(
+            "FILE_REMOVED",
+            _path_risk(removed, "medium"),
+            "Files exist only in the published RPM.",
+            affected_files=removed,
+            analysis_status="needs_review",
+            confidence=0.75,
+        ))
+
+    mtime_only = []
+    permission_entries = []
+    symlink_paths = []
+    buildid_symlink_paths = []
+    doc_content = []
+    config_content = []
+    script_content = []
+    compressed_content = []
+    debug_content = []
+    binary_candidates = []
+    other_content = []
+    other_metadata = []
+
+    for entry in file_analysis["changed"]:
+        path = entry["path"]
+        fields = set(entry["changed_fields"])
+        published = entry["published"]
+        rebuilt = entry["rebuilt"]
+
+        if fields == set(["mtime"]):
+            mtime_only.append(path)
+            continue
+
+        if "linkto" in fields:
+            if _is_buildid_path(path):
+                buildid_symlink_paths.append(path)
+            else:
+                symlink_paths.append(path)
+
+        if fields & set(["mode", "owner", "group", "rdev"]):
+            permission_entries.append(entry)
+
+        if fields & set(["digest", "size"]):
+            if _is_buildid_path(path):
+                buildid_symlink_paths.append(path)
+            elif _is_debug_path(path):
+                debug_content.append(path)
+            elif _is_compressed_path(path) and _is_doc_path(path, published):
+                compressed_content.append(path)
+            elif _is_doc_path(path, published):
+                doc_content.append(path)
+            elif _is_config_path(path, published):
+                config_content.append(path)
+            elif _is_script_path(path):
+                script_content.append(path)
+            elif _is_binary_candidate(path, published, rebuilt):
+                binary_candidates.append(path)
+            else:
+                other_content.append(path)
+
+        metadata_only = fields - set(["mtime", "digest", "size", "mode", "owner", "group", "rdev", "linkto"])
+        if metadata_only:
+            other_metadata.append(path)
+
+    if mtime_only:
+        items.append(_new_diff_item(
+            "FILE_TIMESTAMP",
+            "none",
+            "File mtimes differ while content and attributes are equal.",
+            affected_files=mtime_only,
+            confidence=0.98,
+        ))
+    if permission_entries:
+        items.append(_new_diff_item(
+            "FILE_PERMISSION",
+            _permission_risk(permission_entries),
+            "File mode, owner, group, or device metadata differs.",
+            affected_files=[entry["path"] for entry in permission_entries],
+            analysis_status="needs_review",
+            confidence=0.85,
+        ))
+    if buildid_symlink_paths:
+        items.append(_new_diff_item(
+            "BUILDID_SYMLINK",
+            "none",
+            ".build-id symlink targets or entries differ.",
+            affected_files=buildid_symlink_paths,
+            confidence=0.8,
+        ))
+    if symlink_paths:
+        items.append(_new_diff_item(
+            "SYMLINK_TARGET",
+            _path_risk(symlink_paths, "low"),
+            "Symlink targets differ.",
+            affected_files=symlink_paths,
+            analysis_status="needs_review",
+            confidence=0.8,
+        ))
+    if compressed_content:
+        items.append(_new_diff_item(
+            "COMPRESSION",
+            "low",
+            "Compressed documentation differs; light mode did not decompress logical content.",
+            affected_files=compressed_content,
+            analysis_status="needs_deep_analysis",
+            confidence=0.4,
+            possible_diff_types=["COMPRESSION", "DOC_CONTENT"],
+        ))
+    if doc_content:
+        items.append(_new_diff_item(
+            "DOC_CONTENT",
+            "low",
+            "Documentation content differs.",
+            affected_files=doc_content,
+            confidence=0.8,
+        ))
+    if config_content:
+        items.append(_new_diff_item(
+            "CONFIG_CONTENT",
+            _path_risk(config_content, "low"),
+            "Configuration file content differs.",
+            affected_files=config_content,
+            analysis_status="needs_review",
+            confidence=0.8,
+        ))
+    if script_content:
+        items.append(_new_diff_item(
+            "SCRIPT_CONTENT",
+            _path_risk(script_content, "medium"),
+            "Packaged script file content differs.",
+            affected_files=script_content,
+            analysis_status="needs_review",
+            confidence=0.75,
+        ))
+    if debug_content:
+        items.append(_new_diff_item(
+            "DEBUG_INFO",
+            "low",
+            "Debug information content differs.",
+            affected_files=debug_content,
+            confidence=0.75,
+        ))
+    if binary_candidates:
+        items.append(_new_diff_item(
+            "OTHER",
+            "medium",
+            "Executable or library content differs; light mode did not inspect ELF sections or BuildID.",
+            affected_files=binary_candidates,
+            analysis_status="needs_deep_analysis",
+            confidence=0.35,
+            possible_diff_types=["BINARY_CODE", "BINARY_BUILDID", "DEBUG_INFO"],
+        ))
+    if other_content:
+        items.append(_new_diff_item(
+            "OTHER",
+            "medium",
+            "File content differs and was not classified by light rules.",
+            affected_files=other_content,
+            analysis_status="needs_deep_analysis",
+            confidence=0.35,
+        ))
+    if other_metadata:
+        items.append(_new_diff_item(
+            "OTHER",
+            "low",
+            "RPM file flags differ and were not classified by light rules.",
+            affected_files=other_metadata,
+            analysis_status="needs_review",
+            confidence=0.6,
+        ))
+    return items
+
+
+def _classify_dependency_and_scriptlet_differences(requires_equal, provides_equal, scripts_equal):
+    items = []
+    if not scripts_equal:
+        items.append(_new_diff_item(
+            "SCRIPT_CONTENT",
+            "high",
+            "RPM scriptlets differ.",
+            analysis_status="needs_review",
+            confidence=0.9,
+        ))
+    changed = []
+    if not requires_equal:
+        changed.append("requires")
+    if not provides_equal:
+        changed.append("provides")
+    if changed:
+        items.append(_new_diff_item(
+            "OTHER",
+            "medium",
+            "RPM dependency metadata differs.",
+            fields=changed,
+            analysis_status="needs_review",
+            confidence=0.75,
+        ))
+    return items
+
+
+def _summarize_diff_items(diff_items):
+    by_risk = dict((level, 0) for level in RISK_LEVELS)
+    by_type = {}
+    for item in diff_items:
+        risk = item.get("risk_level", "none")
+        diff_type = item.get("diff_type", "OTHER")
+        by_risk[risk] = by_risk.get(risk, 0) + 1
+        by_type[diff_type] = by_type.get(diff_type, 0) + 1
+    return {
+        "total_diff_types": len(by_type),
+        "total_diff_items": len(diff_items),
+        "diff_by_risk_level": by_risk,
+        "diff_by_type": by_type,
+        "needs_deep_analysis_count": len([
+            item for item in diff_items
+            if item.get("analysis_status") == "needs_deep_analysis"
+        ]),
+        "needs_review_count": len([
+            item for item in diff_items
+            if item.get("analysis_status") == "needs_review"
+        ]),
+    }
+
+
+def _assessment_confidence(diff_items):
+    if not diff_items:
+        return 1.0
+    return round(min(item.get("confidence", 0.5) for item in diff_items), 2)
+
+
+def _build_overall_assessment(rpm_file_sha256_equal, diff_items):
+    if rpm_file_sha256_equal:
+        return {
+            "risk_level": "none",
+            "action": "pass",
+            "reproducible": True,
+            "confidence": 1.0,
+            "trust_level": "L4",
+            "conclusion": "Published and rebuilt RPM files are byte-identical.",
+        }
+
+    highest = _highest_risk(diff_items)
+    has_deep_gap = any(
+        item.get("analysis_status") == "needs_deep_analysis"
+        for item in diff_items
+    )
+    has_review_gap = any(
+        item.get("analysis_status") == "needs_review"
+        for item in diff_items
+    )
+
+    if highest in ("critical", "high"):
+        trust_level = "L0"
+        action = "block"
+        conclusion = "High-risk or security-sensitive differences were found."
+    elif highest == "medium":
+        trust_level = "L1"
+        action = "review"
+        conclusion = "Unexpected or unresolved medium-risk differences were found."
+    elif has_deep_gap or has_review_gap:
+        trust_level = "L1"
+        action = "review"
+        conclusion = "Low-risk differences need review because light analysis could not fully explain them."
+    else:
+        trust_level = "L3"
+        action = "pass"
+        conclusion = "Only expected rebuild wrapper or timestamp differences were found by light analysis."
+
+    return {
+        "risk_level": highest,
+        "action": action,
+        "reproducible": False,
+        "confidence": _assessment_confidence(diff_items),
+        "trust_level": trust_level,
+        "conclusion": conclusion,
+    }
+
+
+def _analysis_capabilities():
+    return {
+        "rpm_header": True,
+        "rpm_file_manifest": True,
+        "rpm_scriptlet": True,
+        "path_based_classification": True,
+        "elf_section_compare": False,
+        "elf_buildid_compare": False,
+        "payload_decompression_compare": False,
+    }
+
+
+def build_light_assessment(
+    rpm_file_sha256_equal,
+    header_diff,
+    files_diff,
+    file_analysis,
+    requires_equal,
+    provides_equal,
+    scripts_equal,
+):
+    diff_items = []
+    if not rpm_file_sha256_equal:
+        diff_items.extend(_classify_header_differences(header_diff))
+        diff_items.extend(_classify_file_differences(files_diff, file_analysis))
+        diff_items.extend(_classify_dependency_and_scriptlet_differences(
+            requires_equal,
+            provides_equal,
+            scripts_equal,
+        ))
+
+    return {
+        "analysis_mode": "light",
+        "analysis_capabilities": _analysis_capabilities(),
+        "unsupported_precise_types": UNSUPPORTED_PRECISE_TYPES,
+        "overall_assessment": _build_overall_assessment(
+            rpm_file_sha256_equal,
+            diff_items,
+        ),
+        "diff_items": diff_items,
+        "summary_stats": _summarize_diff_items(diff_items),
+    }

--- a/src/guanfu/koji_rebuild/assessment.py
+++ b/src/guanfu/koji_rebuild/assessment.py
@@ -88,19 +88,25 @@ def _limited_files(paths):
 def _new_diff_item(
     diff_type,
     risk_level,
-    description,
     affected_files=None,
     fields=None,
-    analysis_status="analyzed",
-    confidence=0.9,
     possible_diff_types=None,
+    expected_environment=False,
+    explained=False,
+    unexpected=False,
+    security_relevant=False,
+    needs_deep_analysis=False,
+    unresolved=False,
 ):
     item = {
         "diff_type": diff_type,
         "risk_level": risk_level,
-        "analysis_status": analysis_status,
-        "confidence": confidence,
-        "description": description,
+        "_expected_environment": expected_environment,
+        "_explained": explained,
+        "_unexpected": unexpected,
+        "_security_relevant": security_relevant,
+        "_needs_deep_analysis": needs_deep_analysis,
+        "_unresolved": unresolved,
     }
     if fields:
         item["fields"] = sorted(fields)
@@ -112,6 +118,18 @@ def _new_diff_item(
     if possible_diff_types:
         item["possible_diff_types"] = possible_diff_types
     return item
+
+
+def _public_diff_item(item):
+    return dict((key, value) for key, value in item.items() if not key.startswith("_"))
+
+
+def _public_diff_items(items):
+    return [_public_diff_item(item) for item in items]
+
+
+def _affected_count(item):
+    return item.get("affected_file_count", 1)
 
 
 def _is_buildid_path(path):
@@ -195,6 +213,10 @@ def _path_risk(paths, default_risk="medium"):
     return risk
 
 
+def _paths_security_relevant(paths):
+    return any(_is_sensitive_path(path) for path in paths)
+
+
 def _permission_risk(entries):
     risk = "low"
     for entry in entries:
@@ -205,6 +227,15 @@ def _permission_risk(entries):
         elif _is_sensitive_path(entry["path"]):
             risk = _risk_at_least("medium", risk)
     return risk
+
+
+def _permission_security_relevant(entries):
+    for entry in entries:
+        if _has_special_exec_bit(entry["published"]) or _has_special_exec_bit(entry["rebuilt"]):
+            return True
+        if _is_sensitive_path(entry["path"]):
+            return True
+    return False
 
 
 def _classify_header_differences(header_diff):
@@ -229,43 +260,36 @@ def _classify_header_differences(header_diff):
         items.append(_new_diff_item(
             "RPM_SIGNATURE",
             "low",
-            "RPM signature-related header fields differ.",
             fields=signature_fields,
-            confidence=0.95,
+            expected_environment=True,
         ))
     if metadata_fields:
         items.append(_new_diff_item(
             "RPM_METADATA",
             "low",
-            "RPM build metadata or wrapper digests differ.",
             fields=metadata_fields,
-            confidence=0.9,
+            expected_environment=True,
         ))
     if compression_fields:
         items.append(_new_diff_item(
             "COMPRESSION",
             "none",
-            "RPM payload compression settings differ.",
             fields=compression_fields,
-            confidence=0.9,
+            explained=True,
         ))
     if identity_fields:
         items.append(_new_diff_item(
             "OTHER",
             "medium",
-            "RPM identity or package size header fields differ.",
             fields=identity_fields,
-            analysis_status="needs_review",
-            confidence=0.7,
+            unresolved=True,
         ))
     if other_fields:
         items.append(_new_diff_item(
             "OTHER",
             "medium",
-            "Unclassified RPM header fields differ.",
             fields=other_fields,
-            analysis_status="needs_review",
-            confidence=0.65,
+            unresolved=True,
         ))
     return items
 
@@ -275,9 +299,7 @@ def _classify_file_differences(files_diff, file_analysis):
         return [_new_diff_item(
             "OTHER",
             "high",
-            "RPM file manifest comparison failed.",
-            analysis_status="needs_review",
-            confidence=0.5,
+            unresolved=True,
         )]
 
     if not file_analysis:
@@ -295,27 +317,24 @@ def _classify_file_differences(files_diff, file_analysis):
         items.append(_new_diff_item(
             "BUILDID_SYMLINK",
             "none",
-            ".build-id symlink entries were added or removed.",
             affected_files=buildid_added + buildid_removed,
-            confidence=0.85,
+            expected_environment=True,
         ))
     if added:
         items.append(_new_diff_item(
             "FILE_ADDED",
             _path_risk(added, "medium"),
-            "Files exist only in the rebuilt RPM.",
             affected_files=added,
-            analysis_status="needs_review",
-            confidence=0.75,
+            unexpected=True,
+            security_relevant=_paths_security_relevant(added),
         ))
     if removed:
         items.append(_new_diff_item(
             "FILE_REMOVED",
             _path_risk(removed, "medium"),
-            "Files exist only in the published RPM.",
             affected_files=removed,
-            analysis_status="needs_review",
-            confidence=0.75,
+            unexpected=True,
+            security_relevant=_paths_security_relevant(removed),
         ))
 
     mtime_only = []
@@ -376,107 +395,94 @@ def _classify_file_differences(files_diff, file_analysis):
         items.append(_new_diff_item(
             "FILE_TIMESTAMP",
             "none",
-            "File mtimes differ while content and attributes are equal.",
             affected_files=mtime_only,
-            confidence=0.98,
+            expected_environment=True,
         ))
     if permission_entries:
         items.append(_new_diff_item(
             "FILE_PERMISSION",
             _permission_risk(permission_entries),
-            "File mode, owner, group, or device metadata differs.",
             affected_files=[entry["path"] for entry in permission_entries],
-            analysis_status="needs_review",
-            confidence=0.85,
+            unexpected=True,
+            security_relevant=_permission_security_relevant(permission_entries),
         ))
     if buildid_symlink_paths:
         items.append(_new_diff_item(
             "BUILDID_SYMLINK",
             "none",
-            ".build-id symlink targets or entries differ.",
             affected_files=buildid_symlink_paths,
-            confidence=0.8,
+            expected_environment=True,
         ))
     if symlink_paths:
         items.append(_new_diff_item(
             "SYMLINK_TARGET",
             _path_risk(symlink_paths, "low"),
-            "Symlink targets differ.",
             affected_files=symlink_paths,
-            analysis_status="needs_review",
-            confidence=0.8,
+            explained=not _paths_security_relevant(symlink_paths),
+            unexpected=_paths_security_relevant(symlink_paths),
+            security_relevant=_paths_security_relevant(symlink_paths),
         ))
     if compressed_content:
         items.append(_new_diff_item(
             "COMPRESSION",
             "low",
-            "Compressed documentation differs; light mode did not decompress logical content.",
             affected_files=compressed_content,
-            analysis_status="needs_deep_analysis",
-            confidence=0.4,
-            possible_diff_types=["COMPRESSION", "DOC_CONTENT"],
+            possible_diff_types=["DOC_CONTENT"],
+            unexpected=True,
+            needs_deep_analysis=True,
         ))
     if doc_content:
         items.append(_new_diff_item(
             "DOC_CONTENT",
             "low",
-            "Documentation content differs.",
             affected_files=doc_content,
-            confidence=0.8,
+            explained=True,
         ))
     if config_content:
         items.append(_new_diff_item(
             "CONFIG_CONTENT",
             _path_risk(config_content, "low"),
-            "Configuration file content differs.",
             affected_files=config_content,
-            analysis_status="needs_review",
-            confidence=0.8,
+            unexpected=True,
+            security_relevant=_paths_security_relevant(config_content),
         ))
     if script_content:
         items.append(_new_diff_item(
             "SCRIPT_CONTENT",
             _path_risk(script_content, "medium"),
-            "Packaged script file content differs.",
             affected_files=script_content,
-            analysis_status="needs_review",
-            confidence=0.75,
+            security_relevant=True,
         ))
     if debug_content:
         items.append(_new_diff_item(
             "DEBUG_INFO",
             "low",
-            "Debug information content differs.",
             affected_files=debug_content,
-            confidence=0.75,
+            explained=True,
         ))
     if binary_candidates:
         items.append(_new_diff_item(
             "OTHER",
             "medium",
-            "Executable or library content differs; light mode did not inspect ELF sections or BuildID.",
             affected_files=binary_candidates,
-            analysis_status="needs_deep_analysis",
-            confidence=0.35,
             possible_diff_types=["BINARY_CODE", "BINARY_BUILDID", "DEBUG_INFO"],
+            needs_deep_analysis=True,
+            unresolved=True,
         ))
     if other_content:
         items.append(_new_diff_item(
             "OTHER",
             "medium",
-            "File content differs and was not classified by light rules.",
             affected_files=other_content,
-            analysis_status="needs_deep_analysis",
-            confidence=0.35,
+            needs_deep_analysis=True,
+            unresolved=True,
         ))
     if other_metadata:
         items.append(_new_diff_item(
             "OTHER",
             "low",
-            "RPM file flags differ and were not classified by light rules.",
             affected_files=other_metadata,
-            analysis_status="needs_review",
-            confidence=0.6,
+            unexpected=True,
         ))
     return items
 
@@ -487,9 +493,7 @@ def _classify_dependency_and_scriptlet_differences(requires_equal, provides_equa
         items.append(_new_diff_item(
             "SCRIPT_CONTENT",
             "high",
-            "RPM scriptlets differ.",
-            analysis_status="needs_review",
-            confidence=0.9,
+            security_relevant=True,
         ))
     changed = []
     if not requires_equal:
@@ -500,89 +504,97 @@ def _classify_dependency_and_scriptlet_differences(requires_equal, provides_equa
         items.append(_new_diff_item(
             "OTHER",
             "medium",
-            "RPM dependency metadata differs.",
             fields=changed,
-            analysis_status="needs_review",
-            confidence=0.75,
+            security_relevant=True,
         ))
     return items
 
 
-def _summarize_diff_items(diff_items):
+def _summarize_diff_items(items):
+    public_items = _public_diff_items(items)
     by_risk = dict((level, 0) for level in RISK_LEVELS)
     by_type = {}
-    for item in diff_items:
+    for item in public_items:
         risk = item.get("risk_level", "none")
         diff_type = item.get("diff_type", "OTHER")
         by_risk[risk] = by_risk.get(risk, 0) + 1
         by_type[diff_type] = by_type.get(diff_type, 0) + 1
     return {
         "total_diff_types": len(by_type),
-        "total_diff_items": len(diff_items),
+        "total_diff_items": len(public_items),
         "diff_by_risk_level": by_risk,
         "diff_by_type": by_type,
         "needs_deep_analysis_count": len([
-            item for item in diff_items
-            if item.get("analysis_status") == "needs_deep_analysis"
-        ]),
-        "needs_review_count": len([
-            item for item in diff_items
-            if item.get("analysis_status") == "needs_review"
+            item for item in items
+            if item.get("_needs_deep_analysis")
         ]),
     }
 
 
-def _assessment_confidence(diff_items):
-    if not diff_items:
-        return 1.0
-    return round(min(item.get("confidence", 0.5) for item in diff_items), 2)
+def _unexpected_affected_count(items):
+    return sum(
+        _affected_count(item)
+        for item in items
+        if item.get("_unexpected")
+    )
 
 
-def _build_overall_assessment(rpm_file_sha256_equal, diff_items):
+def _trust_level(rpm_file_sha256_equal, items):
     if rpm_file_sha256_equal:
-        return {
-            "risk_level": "none",
-            "action": "pass",
-            "reproducible": True,
-            "confidence": 1.0,
-            "trust_level": "L4",
-            "conclusion": "Published and rebuilt RPM files are byte-identical.",
-        }
+        return "L4"
 
-    highest = _highest_risk(diff_items)
-    has_deep_gap = any(
-        item.get("analysis_status") == "needs_deep_analysis"
-        for item in diff_items
-    )
-    has_review_gap = any(
-        item.get("analysis_status") == "needs_review"
-        for item in diff_items
-    )
+    if any(item.get("_security_relevant") for item in items):
+        return "L0"
+    if any(item.get("_unresolved") for item in items):
+        return "L0"
 
-    if highest in ("critical", "high"):
-        trust_level = "L0"
-        action = "block"
-        conclusion = "High-risk or security-sensitive differences were found."
-    elif highest == "medium":
-        trust_level = "L1"
-        action = "review"
-        conclusion = "Unexpected or unresolved medium-risk differences were found."
-    elif has_deep_gap or has_review_gap:
-        trust_level = "L1"
-        action = "review"
-        conclusion = "Low-risk differences need review because light analysis could not fully explain them."
-    else:
-        trust_level = "L3"
-        action = "pass"
-        conclusion = "Only expected rebuild wrapper or timestamp differences were found by light analysis."
+    non_expected = [
+        item for item in items
+        if not item.get("_expected_environment")
+    ]
+    if not non_expected:
+        return "L3"
 
+    if all(item.get("_explained") for item in non_expected):
+        return "L2"
+
+    if _unexpected_affected_count(items) <= 3:
+        return "L1"
+    return "L0"
+
+
+def _action_for_trust_level(trust_level):
+    if trust_level in ("L4", "L3"):
+        return "approve"
+    if trust_level in ("L2", "L1"):
+        return "review"
+    return "reject"
+
+
+def _assessment_confidence(trust_level, items):
+    if trust_level == "L4":
+        return 1.0
+    if any(item.get("_unresolved") for item in items):
+        return 0.55
+    if any(item.get("_needs_deep_analysis") for item in items):
+        return 0.6
+    if trust_level == "L3":
+        return 0.9
+    if trust_level == "L2":
+        return 0.8
+    if trust_level == "L1":
+        return 0.7
+    return 0.85
+
+
+def _build_overall_assessment(rpm_file_sha256_equal, items):
+    trust_level = _trust_level(rpm_file_sha256_equal, items)
     return {
-        "risk_level": highest,
-        "action": action,
-        "reproducible": False,
-        "confidence": _assessment_confidence(diff_items),
+        "risk_level": "none" if rpm_file_sha256_equal else _highest_risk(items),
+        "action": _action_for_trust_level(trust_level),
+        "reproducible": bool(rpm_file_sha256_equal),
+        "confidence": _assessment_confidence(trust_level, items),
         "trust_level": trust_level,
-        "conclusion": conclusion,
     }
 
 
@@ -607,24 +619,26 @@ def build_light_assessment(
     provides_equal,
     scripts_equal,
 ):
-    diff_items = []
+    internal_items = []
     if not rpm_file_sha256_equal:
-        diff_items.extend(_classify_header_differences(header_diff))
-        diff_items.extend(_classify_file_differences(files_diff, file_analysis))
-        diff_items.extend(_classify_dependency_and_scriptlet_differences(
+        internal_items.extend(_classify_header_differences(header_diff))
+        internal_items.extend(_classify_file_differences(files_diff, file_analysis))
+        internal_items.extend(_classify_dependency_and_scriptlet_differences(
             requires_equal,
             provides_equal,
             scripts_equal,
         ))
 
     return {
-        "analysis_mode": "light",
-        "analysis_capabilities": _analysis_capabilities(),
-        "unsupported_precise_types": UNSUPPORTED_PRECISE_TYPES,
+        "analysis": {
+            "mode": "light",
+            "capabilities": _analysis_capabilities(),
+            "unsupported_precise_types": UNSUPPORTED_PRECISE_TYPES,
+        },
         "overall_assessment": _build_overall_assessment(
             rpm_file_sha256_equal,
-            diff_items,
+            internal_items,
         ),
-        "diff_items": diff_items,
-        "summary_stats": _summarize_diff_items(diff_items),
+        "diff_items": _public_diff_items(internal_items),
+        "summary_stats": _summarize_diff_items(internal_items),
     }

--- a/src/guanfu/koji_rebuild/command.py
+++ b/src/guanfu/koji_rebuild/command.py
@@ -1,8 +1,10 @@
 import re
 import sys
 import time
+from datetime import datetime
 from pathlib import Path
 
+from guanfu.koji_rebuild.assessment import ASSESSMENT_VERSION
 from guanfu.koji_rebuild.client import KojiClient
 from guanfu.koji_rebuild.compare import compare_published_and_rebuilt, compare_srpms
 from guanfu.koji_rebuild.downloader import (
@@ -20,6 +22,10 @@ from guanfu.koji_rebuild.rpm_name import parse_rpm_filename, rpm_filename
 
 def _safe_name(name):
     return re.sub(r"[^A-Za-z0-9_.+-]+", "_", name)
+
+
+def _analysis_time():
+    return datetime.now().astimezone().isoformat()
 
 
 def _run_dir(workdir, rpm_name):
@@ -54,6 +60,163 @@ def _download_published(url, dest, label):
     return path, summarize_file(path, label=label, url=url)
 
 
+def _without_none(data):
+    return dict((key, value) for key, value in data.items() if value is not None)
+
+
+def _public_artifact(summary, source_type=None, url=None, task_id=None):
+    if not summary:
+        return None
+    artifact = {}
+    for key in ("file", "url", "size", "sha256", "error"):
+        if key in summary:
+            artifact[key] = summary[key]
+    if url:
+        artifact["url"] = url
+    if source_type:
+        artifact["source_type"] = source_type
+    if task_id:
+        artifact["task_id"] = task_id
+    return _without_none(artifact)
+
+
+def _srpm_cross_check_summary(cross_check):
+    if not cross_check or cross_check.get("status") == "skipped":
+        return {"status": "skipped"}
+    return {
+        "status": cross_check.get("status"),
+        "file_sha256_equal": cross_check.get("file_sha256_equal"),
+        "published_srpm_sha256": cross_check.get("published_srpm_sha256"),
+        "koji_task_srpm_sha256": cross_check.get("koji_task_srpm_sha256"),
+    }
+
+
+def _build_environment_summary(args, resolution=None, repo_probe=None, mock_cfg=None):
+    buildroot = resolution.buildroot if resolution else {}
+    environment = {
+        "koji_server": args.koji_server,
+        "koji_topurl": args.koji_topurl,
+        "buildroot_id": buildroot.get("id"),
+        "buildroot_tag": buildroot.get("tag_name"),
+        "buildroot_arch": buildroot.get("arch"),
+        "buildroot_repo_id": buildroot.get("repo_id"),
+        "historical_repo_url": repo_probe.get("url") if repo_probe else None,
+        "historical_repo_available": repo_probe.get("status") == 200 if repo_probe else None,
+    }
+    if mock_cfg:
+        environment["mock_config"] = _public_artifact(summarize_file(mock_cfg))
+    return _without_none(environment)
+
+
+def _rebuild_summary(args, status, rebuilds=None, repeatable=None, reason=None, error=None):
+    summary = {
+        "tool": "mock",
+        "status": status,
+        "runs": args.runs,
+        "isolation": args.isolation,
+    }
+    if reason:
+        summary["reason"] = reason
+    if error:
+        summary["error"] = error
+    if repeatable is not None:
+        summary["repeatable_by_rpm_sha256"] = repeatable
+    if rebuilds:
+        summary["runs_detail"] = [
+            {
+                "run": item.get("run"),
+                "exit_code": item.get("exit_code"),
+                "elapsed_seconds": item.get("elapsed_seconds"),
+                "rpms": [_public_artifact(rpm) for rpm in item.get("rpms", [])],
+            }
+            for item in rebuilds
+        ]
+    return summary
+
+
+def _unavailable_assessment(field, confidence=0.9):
+    return {
+        "overall_assessment": {
+            "risk_level": "critical",
+            "action": "reject",
+            "reproducible": False,
+            "confidence": confidence,
+            "trust_level": "L0",
+        },
+        "diff_items": [
+            {
+                "diff_type": "OTHER",
+                "risk_level": "critical",
+                "fields": [field],
+            }
+        ],
+        "summary_stats": {
+            "total_diff_types": 1,
+            "total_diff_items": 1,
+            "diff_by_risk_level": {
+                "none": 0,
+                "low": 0,
+                "medium": 0,
+                "high": 0,
+                "critical": 1,
+            },
+            "diff_by_type": {"OTHER": 1},
+            "needs_deep_analysis_count": 0,
+        },
+    }
+
+
+def _analysis_summary():
+    return {
+        "mode": "light",
+        "capabilities": {
+            "rpm_header": True,
+            "rpm_file_manifest": True,
+            "rpm_scriptlet": True,
+            "path_based_classification": True,
+            "elf_section_compare": False,
+            "elf_buildid_compare": False,
+            "payload_decompression_compare": False,
+        },
+        "unsupported_precise_types": ["BINARY_CODE", "BINARY_BUILDID"],
+    }
+
+
+def _input_artifacts_summary(
+    published_rpm_summary=None,
+    task_srpm_summary=None,
+    log_summaries=None,
+    source_rpm_summary=None,
+    source_rpm_type=None,
+    source_rpm_url=None,
+    task_id=None,
+    srpm_cross_check=None,
+):
+    artifacts = {
+        "reference_rpm": _public_artifact(
+            published_rpm_summary,
+            source_type="published_binary_repo",
+        ),
+        "source_rpm": _public_artifact(
+            source_rpm_summary,
+            source_type=source_rpm_type,
+            url=source_rpm_url,
+            task_id=task_id if source_rpm_type == "koji_task_output" else None,
+        ),
+        "koji_task_srpm": _public_artifact(
+            task_srpm_summary,
+            source_type="koji_task_output",
+            task_id=task_id,
+        ),
+        "koji_logs": [
+            _public_artifact(item, source_type="koji_task_output", task_id=task_id)
+            for item in (log_summaries or [])
+        ],
+        "source_rpm_cross_check": _srpm_cross_check_summary(srpm_cross_check),
+    }
+    return _without_none(artifacts)
+
+
 def run_koji_rpm_rebuild(args):
     if args.slsa_provenance:
         print(
@@ -76,16 +239,15 @@ def run_koji_rpm_rebuild(args):
     metadata_dir.mkdir(parents=True, exist_ok=True)
 
     report = {
-        "input": {
-            "rpm_name": args.rpm_name,
-            "koji_server": args.koji_server,
-            "koji_topurl": args.koji_topurl,
-            "binary_rpm_base_url": args.binary_rpm_base_url,
-            "source_rpm_base_url": args.source_rpm_base_url,
-            "runs": args.runs,
-            "isolation": args.isolation,
+        "version": ASSESSMENT_VERSION,
+        "metadata": {
+            "package_name": args.rpm_name,
+            "analysis_time": _analysis_time(),
         },
-        "workdir": str(run_dir),
+        "input_artifacts": {},
+        "build_environment": _build_environment_summary(args),
+        "rebuild": _rebuild_summary(args, "started"),
+        "analysis": _analysis_summary(),
     }
 
     try:
@@ -101,11 +263,21 @@ def run_koji_rpm_rebuild(args):
         write_json(metadata_dir / "task-result.json", resolution.task_result)
 
         repo_probe = probe_repodata(args.koji_topurl, resolution.buildroot)
-        report["repo_probe"] = repo_probe
         write_json(metadata_dir / "repo-probe.json", repo_probe)
         if repo_probe.get("status") != 200:
-            report["status"] = "skipped"
-            report["reason"] = "original buildroot repo repomd.xml is not available"
+            report["metadata"]["package_name"] = target_rpm_name
+            report["metadata"]["analysis_time"] = _analysis_time()
+            report["build_environment"] = _build_environment_summary(
+                args,
+                resolution=resolution,
+                repo_probe=repo_probe,
+            )
+            report["rebuild"] = _rebuild_summary(
+                args,
+                "skipped",
+                reason="original buildroot repo repomd.xml is not available",
+            )
+            report.update(_unavailable_assessment("historical_repo"))
             write_json(run_dir / "report.json", report)
             print(f"[guanfu] Historical repo is not available: {repo_probe.get('url')}", file=sys.stderr)
             return 3
@@ -139,20 +311,17 @@ def run_koji_rpm_rebuild(args):
             inputs_dir,
         )
 
-        downloads = [published_rpm_summary, task_srpm_summary] + log_summaries
-        if published_srpm_summary:
-            downloads.insert(1, published_srpm_summary)
-        report["downloads"] = downloads
-
         srpm_for_rebuild = published_srpm
-        report["srpm_source"] = "openanolis_source_mirror"
-        report["srpm_is_published_artifact"] = True
+        source_rpm_summary = published_srpm_summary
+        source_rpm_type = "published_source_repo"
+        source_rpm_url = published_srpm_url
         if not srpm_for_rebuild:
             srpm_for_rebuild = task_srpm
-            report["srpm_source"] = "koji_task_fallback"
-            report["srpm_is_published_artifact"] = False
+            source_rpm_summary = task_srpm_summary
+            source_rpm_type = "koji_task_output"
+            source_rpm_url = None
 
-        report["srpm_cross_check"] = compare_srpms(published_srpm, task_srpm)
+        srpm_cross_check = compare_srpms(published_srpm, task_srpm)
 
         mock_cfg = inputs_dir / "mock.cfg"
         generate_mock_config(
@@ -161,10 +330,6 @@ def run_koji_rpm_rebuild(args):
             resolution.buildroot["id"],
             mock_cfg,
         )
-        report["mock_config"] = {
-            "file": str(mock_cfg),
-            "buildroot_id": resolution.buildroot["id"],
-        }
 
         rebuilds = []
         for run_index in range(1, args.runs + 1):
@@ -174,13 +339,12 @@ def run_koji_rpm_rebuild(args):
             rebuilds.append(result)
             if result["exit_code"] != 0:
                 break
-        report["rebuilds"] = rebuilds
 
         successful = rebuilds and all(item["exit_code"] == 0 for item in rebuilds)
-        report["status"] = "rebuilt" if successful else "failed"
+        repeatable = None
         if successful:
             first_run_rpms = [Path(item.get("path", item["file"])) for item in rebuilds[0]["rpms"]]
-            report["comparison"] = compare_published_and_rebuilt(
+            comparison = compare_published_and_rebuilt(
                 published_rpm,
                 first_run_rpms,
                 target_rpm_name,
@@ -188,17 +352,78 @@ def run_koji_rpm_rebuild(args):
             )
             if len(rebuilds) > 1:
                 first = [(rpm["file"], rpm["sha256"]) for rpm in rebuilds[0]["rpms"]]
-                report["repeatable_by_rpm_sha256"] = all(
+                repeatable = all(
                     [(rpm["file"], rpm["sha256"]) for rpm in rebuild["rpms"]] == first
                     for rebuild in rebuilds[1:]
                 )
+
+            report = {
+                "version": ASSESSMENT_VERSION,
+                "metadata": comparison["metadata"],
+                "input_artifacts": _input_artifacts_summary(
+                    published_rpm_summary=published_rpm_summary,
+                    task_srpm_summary=task_srpm_summary,
+                    log_summaries=log_summaries,
+                    source_rpm_summary=source_rpm_summary,
+                    source_rpm_type=source_rpm_type,
+                    source_rpm_url=source_rpm_url,
+                    task_id=resolution.buildarch_task["id"],
+                    srpm_cross_check=srpm_cross_check,
+                ),
+                "build_environment": _build_environment_summary(
+                    args,
+                    resolution=resolution,
+                    repo_probe=repo_probe,
+                    mock_cfg=mock_cfg,
+                ),
+                "rebuild": _rebuild_summary(
+                    args,
+                    "rebuilt",
+                    rebuilds=rebuilds,
+                    repeatable=repeatable,
+                ),
+                "analysis": comparison["analysis"],
+                "overall_assessment": comparison["overall_assessment"],
+                "diff_items": comparison["diff_items"],
+                "summary_stats": comparison["summary_stats"],
+            }
+        else:
+            report = {
+                "version": ASSESSMENT_VERSION,
+                "metadata": {
+                    "package_name": target_rpm_name,
+                    "reference_url": published_rpm_url,
+                    "reference_sha256": published_rpm_summary.get("sha256"),
+                    "rebuild_sha256": None,
+                    "analysis_time": _analysis_time(),
+                },
+                "input_artifacts": _input_artifacts_summary(
+                    published_rpm_summary=published_rpm_summary,
+                    task_srpm_summary=task_srpm_summary,
+                    log_summaries=log_summaries,
+                    source_rpm_summary=source_rpm_summary,
+                    source_rpm_type=source_rpm_type,
+                    source_rpm_url=source_rpm_url,
+                    task_id=resolution.buildarch_task["id"],
+                    srpm_cross_check=srpm_cross_check,
+                ),
+                "build_environment": _build_environment_summary(
+                    args,
+                    resolution=resolution,
+                    repo_probe=repo_probe,
+                    mock_cfg=mock_cfg,
+                ),
+                "rebuild": _rebuild_summary(args, "failed", rebuilds=rebuilds),
+                "analysis": _analysis_summary(),
+            }
+            report.update(_unavailable_assessment("mock_rebuild", confidence=0.8))
 
         write_json(run_dir / "report.json", report)
         print(f"[guanfu] Koji RPM rebuild report: {run_dir / 'report.json'}")
         return 0 if successful else 1
     except Exception as exc:
-        report["status"] = "error"
-        report["error"] = repr(exc)
+        report["rebuild"] = _rebuild_summary(args, "error", error=repr(exc))
+        report.update(_unavailable_assessment("rebuild_pipeline", confidence=0.7))
         write_json(run_dir / "report.json", report)
         print(f"[guanfu] ERROR: {exc}", file=sys.stderr)
         print(f"[guanfu] Partial report: {run_dir / 'report.json'}", file=sys.stderr)

--- a/src/guanfu/koji_rebuild/command.py
+++ b/src/guanfu/koji_rebuild/command.py
@@ -184,6 +184,7 @@ def run_koji_rpm_rebuild(args):
                 published_rpm,
                 first_run_rpms,
                 target_rpm_name,
+                reference_url=published_rpm_url,
             )
             if len(rebuilds) > 1:
                 first = [(rpm["file"], rpm["sha256"]) for rpm in rebuilds[0]["rpms"]]

--- a/src/guanfu/koji_rebuild/compare.py
+++ b/src/guanfu/koji_rebuild/compare.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from guanfu.koji_rebuild.downloader import sha256_file
 
 
+MAX_DIFF_ITEMS = 50
+
+
 def _run_text(cmd):
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     if proc.returncode != 0:
@@ -18,8 +21,12 @@ def _rpm_query(path):
         "BUILDHOST=%{BUILDHOST}\\n"
         "SOURCERPM=%{SOURCERPM}\\n"
         "PAYLOADDIGEST=%{PAYLOADDIGEST}\\n"
+        "PAYLOADCOMPRESSOR=%{PAYLOADCOMPRESSOR}\\n"
+        "PAYLOADFLAGS=%{PAYLOADFLAGS}\\n"
         "SIGMD5=%{SIGMD5}\\n"
         "SHA256HEADER=%{SHA256HEADER}\\n"
+        "RSAHEADER=%{RSAHEADER:pgpsig}\\n"
+        "SIZE=%{SIZE}\\n"
     )
     out, err = _run_text(["rpm", "-qp", "--qf", query, str(path)])
     if err:
@@ -46,11 +53,174 @@ def _rpm_dump(path):
     return sorted(out.splitlines())
 
 
+def _rpm_dump_map(path):
+    out, err = _run_text(["rpm", "-qp", "--dump", str(path)])
+    if err:
+        return None, err
+
+    files = {}
+    unparsed = []
+    for line in out.splitlines():
+        parsed = _parse_dump_line(line)
+        if not parsed:
+            unparsed.append(line)
+            continue
+        files[parsed["path"]] = parsed
+    return {"files": files, "unparsed": unparsed}, None
+
+
+def _parse_dump_line(line):
+    parts = line.split()
+    if len(parts) < 11:
+        return None
+    path = parts[0]
+    return {
+        "path": path,
+        "size": parts[1],
+        "mtime": parts[2],
+        "digest": parts[3],
+        "mode": parts[4],
+        "owner": parts[5],
+        "group": parts[6],
+        "isconfig": parts[7],
+        "isdoc": parts[8],
+        "rdev": parts[9],
+        "linkto": " ".join(parts[10:]),
+    }
+
+
 def _find_rebuilt_rpm(result_rpms, target_filename):
     for rpm in result_rpms:
         if Path(rpm).name == target_filename:
             return Path(rpm)
     return None
+
+
+def _diff_headers(published_headers, rebuilt_headers):
+    fields = {}
+    keys = sorted(set(published_headers) | set(rebuilt_headers))
+    for key in keys:
+        published = published_headers.get(key)
+        rebuilt = rebuilt_headers.get(key)
+        if published != rebuilt:
+            fields[key] = {
+                "published": published,
+                "rebuilt": rebuilt,
+            }
+    return {
+        "different": bool(fields),
+        "fields": fields,
+    }
+
+
+def _file_brief(item):
+    return {
+        "size": item.get("size"),
+        "mtime": item.get("mtime"),
+        "digest": item.get("digest"),
+        "mode": item.get("mode"),
+        "owner": item.get("owner"),
+        "group": item.get("group"),
+        "linkto": item.get("linkto"),
+    }
+
+
+def _diff_file_entry(published, rebuilt):
+    compared_fields = [
+        "size",
+        "mtime",
+        "digest",
+        "mode",
+        "owner",
+        "group",
+        "isconfig",
+        "isdoc",
+        "rdev",
+        "linkto",
+    ]
+    changed_fields = [
+        field
+        for field in compared_fields
+        if published.get(field) != rebuilt.get(field)
+    ]
+    if not changed_fields:
+        return None
+    return {
+        "path": published["path"],
+        "changed_fields": changed_fields,
+        "published": _file_brief(published),
+        "rebuilt": _file_brief(rebuilt),
+    }
+
+
+def _limit_items(items, limit=MAX_DIFF_ITEMS):
+    return {
+        "count": len(items),
+        "truncated": len(items) > limit,
+        "items": items[:limit],
+    }
+
+
+def _diff_files(published_rpm, rebuilt_rpm):
+    published_dump, published_err = _rpm_dump_map(published_rpm)
+    rebuilt_dump, rebuilt_err = _rpm_dump_map(rebuilt_rpm)
+    if published_err or rebuilt_err:
+        return {
+            "status": "error",
+            "published_error": published_err,
+            "rebuilt_error": rebuilt_err,
+        }
+
+    published_files = published_dump["files"]
+    rebuilt_files = rebuilt_dump["files"]
+    published_paths = set(published_files)
+    rebuilt_paths = set(rebuilt_files)
+
+    only_in_published = sorted(published_paths - rebuilt_paths)
+    only_in_rebuilt = sorted(rebuilt_paths - published_paths)
+
+    changed = []
+    for path in sorted(published_paths & rebuilt_paths):
+        diff = _diff_file_entry(published_files[path], rebuilt_files[path])
+        if diff:
+            changed.append(diff)
+
+    mtime_only = [
+        item
+        for item in changed
+        if item["changed_fields"] == ["mtime"]
+    ]
+    non_mtime = [
+        item
+        for item in changed
+        if set(item["changed_fields"]) - {"mtime"}
+    ]
+    content_related = [
+        item
+        for item in changed
+        if set(item["changed_fields"]) & {"digest", "size", "linkto"}
+    ]
+
+    return {
+        "status": "compared",
+        "published_file_count": len(published_files),
+        "rebuilt_file_count": len(rebuilt_files),
+        "only_in_published": _limit_items(only_in_published),
+        "only_in_rebuilt": _limit_items(only_in_rebuilt),
+        "changed": _limit_items(changed),
+        "mtime_only_changed_count": len(mtime_only),
+        "non_mtime_changed_count": len(non_mtime),
+        "content_related_changed_count": len(content_related),
+        "files_equal_ignoring_mtime": (
+            not only_in_published
+            and not only_in_rebuilt
+            and len(non_mtime) == 0
+        ),
+        "unparsed": {
+            "published_count": len(published_dump["unparsed"]),
+            "rebuilt_count": len(rebuilt_dump["unparsed"]),
+        },
+    }
 
 
 def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename):
@@ -71,24 +241,31 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename):
     published_dump = _rpm_dump(published)
     rebuilt_dump = _rpm_dump(rebuilt)
 
+    published_headers = _rpm_query(published)
+    rebuilt_headers = _rpm_query(rebuilt)
+
     return {
         "status": "compared",
         "target_filename": target_filename,
         "published": {
             "file": str(published),
             "sha256": sha256_file(published),
-            "headers": _rpm_query(published),
+            "headers": published_headers,
         },
         "rebuilt": {
             "file": str(rebuilt),
             "sha256": sha256_file(rebuilt),
-            "headers": _rpm_query(rebuilt),
+            "headers": rebuilt_headers,
         },
         "rpm_file_sha256_equal": sha256_file(published) == sha256_file(rebuilt),
         "requires_equal": published_requires == rebuilt_requires,
         "provides_equal": published_provides == rebuilt_provides,
         "scripts_equal": published_scripts == rebuilt_scripts,
         "dump_equal": published_dump == rebuilt_dump,
+        "differences": {
+            "headers": _diff_headers(published_headers, rebuilt_headers),
+            "files": _diff_files(published, rebuilt),
+        },
     }
 
 

--- a/src/guanfu/koji_rebuild/compare.py
+++ b/src/guanfu/koji_rebuild/compare.py
@@ -1,6 +1,8 @@
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
+from guanfu.koji_rebuild.assessment import ASSESSMENT_VERSION, build_light_assessment
 from guanfu.koji_rebuild.downloader import sha256_file
 
 
@@ -12,6 +14,10 @@ def _run_text(cmd):
     if proc.returncode != 0:
         return None, proc.stderr.strip()
     return proc.stdout, None
+
+
+def _analysis_time():
+    return datetime.now().astimezone().isoformat()
 
 
 def _rpm_query(path):
@@ -121,6 +127,9 @@ def _file_brief(item):
         "mode": item.get("mode"),
         "owner": item.get("owner"),
         "group": item.get("group"),
+        "isconfig": item.get("isconfig"),
+        "isdoc": item.get("isdoc"),
+        "rdev": item.get("rdev"),
         "linkto": item.get("linkto"),
     }
 
@@ -169,7 +178,7 @@ def _diff_files(published_rpm, rebuilt_rpm):
             "status": "error",
             "published_error": published_err,
             "rebuilt_error": rebuilt_err,
-        }
+        }, None
 
     published_files = published_dump["files"]
     rebuilt_files = rebuilt_dump["files"]
@@ -201,7 +210,7 @@ def _diff_files(published_rpm, rebuilt_rpm):
         if set(item["changed_fields"]) & {"digest", "size", "linkto"}
     ]
 
-    return {
+    public_diff = {
         "status": "compared",
         "published_file_count": len(published_files),
         "rebuilt_file_count": len(rebuilt_files),
@@ -221,9 +230,15 @@ def _diff_files(published_rpm, rebuilt_rpm):
             "rebuilt_count": len(rebuilt_dump["unparsed"]),
         },
     }
+    analysis_input = {
+        "only_in_published": only_in_published,
+        "only_in_rebuilt": only_in_rebuilt,
+        "changed": changed,
+    }
+    return public_diff, analysis_input
 
 
-def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename):
+def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename, reference_url=None):
     published = Path(published_rpm)
     rebuilt = _find_rebuilt_rpm(result_rpms, target_filename)
     if not rebuilt:
@@ -243,30 +258,58 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename):
 
     published_headers = _rpm_query(published)
     rebuilt_headers = _rpm_query(rebuilt)
+    header_diff = _diff_headers(published_headers, rebuilt_headers)
+    files_diff, file_analysis = _diff_files(published, rebuilt)
+    published_sha256 = sha256_file(published)
+    rebuilt_sha256 = sha256_file(rebuilt)
+    rpm_file_sha256_equal = published_sha256 == rebuilt_sha256
+    requires_equal = published_requires == rebuilt_requires
+    provides_equal = published_provides == rebuilt_provides
+    scripts_equal = published_scripts == rebuilt_scripts
+    dump_equal = published_dump == rebuilt_dump
+    assessment = build_light_assessment(
+        rpm_file_sha256_equal,
+        header_diff,
+        files_diff,
+        file_analysis,
+        requires_equal,
+        provides_equal,
+        scripts_equal,
+    )
 
-    return {
+    result = {
+        "version": ASSESSMENT_VERSION,
         "status": "compared",
         "target_filename": target_filename,
+        "metadata": {
+            "package_name": target_filename,
+            "reference_url": reference_url,
+            "reference_sha256": published_sha256,
+            "rebuild_sha256": rebuilt_sha256,
+            "analysis_time": _analysis_time(),
+        },
         "published": {
             "file": str(published),
-            "sha256": sha256_file(published),
+            "sha256": published_sha256,
             "headers": published_headers,
         },
         "rebuilt": {
             "file": str(rebuilt),
-            "sha256": sha256_file(rebuilt),
+            "sha256": rebuilt_sha256,
             "headers": rebuilt_headers,
         },
-        "rpm_file_sha256_equal": sha256_file(published) == sha256_file(rebuilt),
-        "requires_equal": published_requires == rebuilt_requires,
-        "provides_equal": published_provides == rebuilt_provides,
-        "scripts_equal": published_scripts == rebuilt_scripts,
-        "dump_equal": published_dump == rebuilt_dump,
+        "rpm_file_sha256_equal": rpm_file_sha256_equal,
+        "requires_equal": requires_equal,
+        "provides_equal": provides_equal,
+        "scripts_equal": scripts_equal,
+        "dump_equal": dump_equal,
         "differences": {
-            "headers": _diff_headers(published_headers, rebuilt_headers),
-            "files": _diff_files(published, rebuilt),
+            "headers": header_diff,
+            "files": files_diff,
         },
     }
+    result.update(assessment)
+    return result
 
 
 def compare_srpms(published_srpm, task_srpm):

--- a/src/guanfu/koji_rebuild/compare.py
+++ b/src/guanfu/koji_rebuild/compare.py
@@ -52,13 +52,6 @@ def _rpm_command_lines(path, option):
     return sorted(out.splitlines())
 
 
-def _rpm_dump(path):
-    out, err = _run_text(["rpm", "-qp", "--dump", str(path)])
-    if err:
-        return {"error": err}
-    return sorted(out.splitlines())
-
-
 def _rpm_dump_map(path):
     out, err = _run_text(["rpm", "-qp", "--dump", str(path)])
     if err:
@@ -243,8 +236,46 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename, r
     rebuilt = _find_rebuilt_rpm(result_rpms, target_filename)
     if not rebuilt:
         return {
-            "status": "missing_rebuilt_target_rpm",
-            "target_filename": target_filename,
+            "version": ASSESSMENT_VERSION,
+            "metadata": {
+                "package_name": target_filename,
+                "reference_url": reference_url,
+                "reference_sha256": sha256_file(published),
+                "rebuild_sha256": None,
+                "analysis_time": _analysis_time(),
+            },
+            "overall_assessment": {
+                "risk_level": "critical",
+                "action": "reject",
+                "reproducible": False,
+                "confidence": 0.9,
+                "trust_level": "L0",
+            },
+            "diff_items": [
+                {
+                    "diff_type": "OTHER",
+                    "risk_level": "critical",
+                    "fields": ["rebuilt_target_rpm"],
+                }
+            ],
+            "summary_stats": {
+                "total_diff_types": 1,
+                "total_diff_items": 1,
+                "diff_by_risk_level": {
+                    "none": 0,
+                    "low": 0,
+                    "medium": 0,
+                    "high": 0,
+                    "critical": 1,
+                },
+                "diff_by_type": {"OTHER": 1},
+                "needs_deep_analysis_count": 0,
+            },
+            "analysis": {
+                "mode": "light",
+                "capabilities": {},
+                "unsupported_precise_types": [],
+            },
         }
 
     published_requires = _rpm_command_lines(published, "--requires")
@@ -253,9 +284,6 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename, r
     rebuilt_provides = _rpm_command_lines(rebuilt, "--provides")
     published_scripts = _rpm_command_lines(published, "--scripts")
     rebuilt_scripts = _rpm_command_lines(rebuilt, "--scripts")
-    published_dump = _rpm_dump(published)
-    rebuilt_dump = _rpm_dump(rebuilt)
-
     published_headers = _rpm_query(published)
     rebuilt_headers = _rpm_query(rebuilt)
     header_diff = _diff_headers(published_headers, rebuilt_headers)
@@ -266,7 +294,6 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename, r
     requires_equal = published_requires == rebuilt_requires
     provides_equal = published_provides == rebuilt_provides
     scripts_equal = published_scripts == rebuilt_scripts
-    dump_equal = published_dump == rebuilt_dump
     assessment = build_light_assessment(
         rpm_file_sha256_equal,
         header_diff,
@@ -279,33 +306,12 @@ def compare_published_and_rebuilt(published_rpm, result_rpms, target_filename, r
 
     result = {
         "version": ASSESSMENT_VERSION,
-        "status": "compared",
-        "target_filename": target_filename,
         "metadata": {
             "package_name": target_filename,
             "reference_url": reference_url,
             "reference_sha256": published_sha256,
             "rebuild_sha256": rebuilt_sha256,
             "analysis_time": _analysis_time(),
-        },
-        "published": {
-            "file": str(published),
-            "sha256": published_sha256,
-            "headers": published_headers,
-        },
-        "rebuilt": {
-            "file": str(rebuilt),
-            "sha256": rebuilt_sha256,
-            "headers": rebuilt_headers,
-        },
-        "rpm_file_sha256_equal": rpm_file_sha256_equal,
-        "requires_equal": requires_equal,
-        "provides_equal": provides_equal,
-        "scripts_equal": scripts_equal,
-        "dump_equal": dump_equal,
-        "differences": {
-            "headers": header_diff,
-            "files": files_diff,
         },
     }
     result.update(assessment)


### PR DESCRIPTION
## Summary
- add structured header field differences to the Koji RPM rebuild report
- add lightweight file-level differences based on `rpm -qp --dump`, including changed fields and mtime/content-related summaries
- document the new report diff fields in the local rebuild guide

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m guanfu.cli rebuild koji-rpm --help`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 - <<PY ...` compare helper smoke test
- `git diff --check`
- remote validation against existing `anolis-release-23.4-14.an23.x86_64.rpm` rebuild artifacts showed header diffs and file diffs; all file changes were mtime-only and files were equal ignoring mtime