### PR TITLE
Make SRPM payload generation reproducible

### DIFF
--- a/src/run_build.py
+++ b/src/run_build.py
@@ -97,6 +97,7 @@ def setup_default_environment() -> None:
 %clamp_mtime_to_source_date_epoch 1
 %use_source_date_epoch_as_buildtime 1
 %_buildhost reproducible
+%_source_payload w.ufdio
 """
     with open('/etc/rpm/macros.buildroot', 'w') as f:
         f.write(rpm_macros_content)


### PR DESCRIPTION
## Summary
- set `%_source_payload w.ufdio` in the default RPM macros
- keep SRPM payloads as uncompressed cpio to avoid non-deterministic gzip byte streams
- leave binary RPM payload behavior unchanged

## Validation
- `python3 -m py_compile src/run_build.py`
- `git diff --check --cached`
- remote validation on `Aliyun-Ubuntu22.04-SGX2.0-HK`: 3 independent SRPM-only rebuilds for `cryptpilot-0.7.0-1.al8.src.rpm` all produced identical SHA256 `e655c5232704f3807cd0d8f5ffbd5c7406cbd65be8c1bbf13a31d00bf7f0a1f1`
- verified rebuilt SRPM headers report `PAYLOADCOMPRESSOR=(none)` and payload bytes start with cpio magic `070701` instead of gzip magic