### PR TITLE
Add Koji RPM rebuild fallback and VM guidance

### DIFF
--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -64,13 +64,75 @@ guanfu rebuild koji-rpm \
   --rpm-name zlib-1.2.13-3.an23.x86_64.rpm
 ```
 
-该流程会：
+`koji-rpm` 默认走容器执行器。当前容器执行器只支持 an23 RPM；如果 Koji buildroot tag 或 RPM release 不能识别为 an23，GuanFu 会返回 `unsupported`，后续 an8、alinux3、alinux4 等发行版会由未来的 policy 模块接入。
+
+默认流程会：
 
 1. 根据 RPM 名称查询 OpenAnolis Koji，定位 buildroot 和构建任务
-2. 从发布 source repo 获取 SRPM，并下载 Koji task SRPM/logs 做同源校验
-3. 使用 Koji `buildroot_id` 生成 `mock.cfg`
-4. 使用 `mock --rebuild` 在本地重建发布 SRPM
-5. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
+2. 判断目标为 an23 后，选择 an23 GuanFu rebuild 容器镜像
+3. 挂载 `--workdir` 到容器内 `/work`，并在容器内以 `--executor local` 重新执行
+4. 从发布 source repo 获取 SRPM，并下载 Koji task SRPM/logs 做同源校验
+5. 使用 Koji `buildroot_id` 生成 `mock.cfg`
+6. 使用容器内的 `mock --rebuild` 重建发布 SRPM
+7. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
+
+如果需要保留当前 host 上直接运行 mock 的行为，可以显式使用 local executor：
+
+```bash
+guanfu rebuild koji-rpm \
+  --rpm-name zlib-1.2.13-3.an23.x86_64.rpm \
+  --executor local
+```
+
+容器执行器的可选参数：
+
+```text
+--container-runtime auto|podman|docker
+--container-image IMAGE
+--container-privileged / --no-container-privileged
+```
+
+`auto` 在 Linux 上优先选择 `podman`，其它平台优先选择 `docker`。默认会传 `--privileged`，因为容器内的 `mock` 需要创建 buildroot/chroot 并执行 RPM 安装事务。
+
+容器执行器会在运行 mock 前改写生成的 `mock.cfg`，将 chroot 内的 `mockbuild` 用户固定为非 root UID，并保留 mock/Koji 配置给出的 group。这样外层容器仍可用 root/privileged 完成 mount 和 chroot 操作，但 SRPM 的 `%build`/`%check` 不会以 root 语义运行。
+
+### VM 环境建议
+
+需要注意，容器执行器解决的是工具链和依赖隔离问题，但容器内的 `mock` 仍然共享宿主机的 kernel 和 CPU 特征暴露。如果历史 buildroot 较旧，在当前宿主或容器环境中执行 RPM scriptlet、`bash`、`glibc` 或 buildroot 工具时，可能出现类似下面的失败：
+
+```text
+scriptlet failed, signal 11
+Segmentation fault
+Illegal instruction
+invalid opcode
+Transaction failed（通常伴随 scriptlet signal 4/11）
+```
+
+这类失败通常不表示 SRPM、`mock.cfg` 或依赖恢复一定有问题，而可能是本地执行环境和 Koji builder 的 CPU/kernel 边界不一致。此时可以在 Linux VM 中运行同一条 GuanFu 命令，通过 KVM/QEMU 固定更接近 Koji builder 的 CPU model。当前 an23 实验中，`Haswell-v4` 和 `Cascadelake-Server-v5` VM 均已验证可以让 old an23 buildroot 正常运行并完成 `attr-2.5.1-5.an23` rebuild。
+
+GuanFu 会在 mock 失败后读取 `root.log`、`build.log` 和 `state.log`。如果检测到上述旧 buildroot 运行时崩溃特征，`report.json` 的 `rebuild.failure_diagnosis` 会给出 `buildroot_runtime_incompatible` 诊断、证据行和 VM 重试建议。
+
+如果原始 Koji buildroot repo 已被清理，默认会启用 `installed-pkgs` fallback：
+
+```text
+installed_pkgs.log
+-> Koji RPM: getRPM -> getBuild/getTaskChildren/listTaskOutput -> downloadTaskOutput
+-> external RPM: getExternalRepoList(tag,event) -> repodata primary -> RPM download -> header 校验
+-> mock bootstrap: 当前 mock 有效配置 -> bootstrap 工具链 RPM 下载
+-> createrepo_c -> 临时本地 repo -> mock
+```
+
+该 fallback 会根据目标构建任务的 `installed_pkgs.log` 恢复当时实际安装进 buildroot 的依赖 RPM。Koji 自身产物会校验 `payloadhash` 并从 task output 下载；Koji 索引中不存在的 external RPM 会按 buildroot 的 tag/event 查询当时绑定的 external repo，再通过 repodata 找到 RPM，并校验 NEVRA、SIGMD5、安装后 size 和 buildtime。为了让本地 mock 能创建 bootstrap chroot，GuanFu 还会按当前本地 mock 有效配置解析 `python3-dnf` 等 bootstrap 工具链包，并把解析到的 RPM 加入临时 repo。随后 GuanFu 会把 `mock.cfg` 的 repo `baseurl` 改写为这个临时本地 repo。
+
+需要注意：external repo 的定义可由 Koji event 查询，但 external repo 内容本身不是 OpenAnolis Koji artifact；bootstrap 工具链来自当前本地 mock 配置，不等同于历史 Koji builder 的确定输入。因此报告会在 `build_environment.repo_fallback.external_repo_recovery` 和 `build_environment.repo_fallback.bootstrap_toolchain` 中记录来源、校验结果和 `historical_exactness`。若依赖解析、校验、task output 定位或下载不完整，GuanFu 不会静默降级到当前 release repo。
+
+可以关闭该行为，恢复为历史 repo 不可用即跳过：
+
+```bash
+guanfu rebuild koji-rpm \
+  --rpm-name grep-3.11-1.an23.x86_64.rpm \
+  --repo-fallback none
+```
 
 `report.json` 会包含轻量差异摘要：
 
@@ -99,4 +161,4 @@ source RPM base URL: https://mirrors.openanolis.cn/anolis/23/os/source/Packages/
 binary RPM base URL: https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/
 ```
 
-Koji RPM rebuild 需要 Linux 环境，并安装 `koji`、`mock`、`rpm` 和 `dnf`。macOS 不能原生运行 `mock`，需要 Linux 虚拟机或远程 Linux 主机。
+默认容器执行器需要本机安装 `podman` 或 `docker`。容器镜像内需要包含 `guanfu`、`koji`、`mock`、`rpm`、`dnf` 和 `createrepo_c`。local executor 需要 Linux 环境，并在 host 上安装这些工具；macOS 不能原生运行 local mock，需要使用容器、Linux 虚拟机或远程 Linux 主机。

--- a/src/guanfu/cli.py
+++ b/src/guanfu/cli.py
@@ -29,6 +29,18 @@ def build_parser():
     koji = rebuild_subparsers.add_parser(
         "koji-rpm",
         help="Rebuild an RPM produced by a Koji instance",
+        description=(
+            "Rebuild an RPM produced by a Koji instance. The default executor runs mock "
+            "inside a container. If an old buildroot crashes while executing RPM scriptlets "
+            "or buildroot tools, rerun GuanFu inside a Linux VM with a controlled CPU model; "
+            "a VM can solve host/container CPU or kernel exposure mismatches."
+        ),
+        epilog=(
+            "VM guidance: container and local executors share the host kernel/CPU exposure. "
+            "For failures such as scriptlet failed with signal 11, segmentation fault, "
+            "illegal instruction, or invalid opcode, use a KVM/QEMU VM close to the Koji "
+            "builder environment and run the same guanfu rebuild koji-rpm command inside it."
+        ),
     )
     source = koji.add_mutually_exclusive_group(required=True)
     source.add_argument(
@@ -65,6 +77,38 @@ def build_parser():
         help="Directory for downloaded inputs, mock config, rebuild results, and reports",
     )
     koji.add_argument(
+        "--executor",
+        choices=("container", "local"),
+        default="container",
+        help=(
+            "Rebuild executor. container is the default path; local keeps the existing host "
+            "mock flow. If both hit old buildroot runtime crashes, run GuanFu inside a VM."
+        ),
+    )
+    koji.add_argument(
+        "--container-runtime",
+        choices=("auto", "podman", "docker"),
+        default="auto",
+        help="Container runtime used by --executor container",
+    )
+    koji.add_argument(
+        "--container-image",
+        help="Container image used by --executor container. Defaults to the an23 GuanFu rebuild image.",
+    )
+    koji.add_argument(
+        "--container-privileged",
+        dest="container_privileged",
+        action="store_true",
+        default=True,
+        help="Run the rebuild container with --privileged. This is the default.",
+    )
+    koji.add_argument(
+        "--no-container-privileged",
+        dest="container_privileged",
+        action="store_false",
+        help="Do not pass --privileged to the container runtime.",
+    )
+    koji.add_argument(
         "--runs",
         type=int,
         default=1,
@@ -74,6 +118,16 @@ def build_parser():
         "--isolation",
         default="simple",
         help="mock isolation mode",
+    )
+    koji.add_argument(
+        "--repo-fallback",
+        choices=("installed-pkgs", "none"),
+        default="installed-pkgs",
+        help=(
+            "Fallback strategy when the original Koji buildroot repo is unavailable. "
+            "installed-pkgs reconstructs a temporary local repo from installed_pkgs.log, "
+            "Koji task outputs, event-time external repos, and local mock bootstrap tooling."
+        ),
     )
     koji.set_defaults(func=run_koji_rpm_rebuild)
 

--- a/src/guanfu/koji_rebuild/client.py
+++ b/src/guanfu/koji_rebuild/client.py
@@ -9,6 +9,12 @@ class KojiClient:
     def get_rpm(self, rpm_info):
         return self.session.getRPM(rpm_info, True, False)
 
+    def get_rpm_optional(self, rpm_info):
+        return self.session.getRPM(rpm_info, False, False)
+
+    def get_external_repo_list(self, tag_info, event=None):
+        return self.session.getExternalRepoList(tag_info, event)
+
     def get_build(self, build_id):
         return self.session.getBuild(build_id, True)
 

--- a/src/guanfu/koji_rebuild/command.py
+++ b/src/guanfu/koji_rebuild/command.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 import time
@@ -7,15 +8,29 @@ from pathlib import Path
 from guanfu.koji_rebuild.assessment import ASSESSMENT_VERSION
 from guanfu.koji_rebuild.client import KojiClient
 from guanfu.koji_rebuild.compare import compare_published_and_rebuilt, compare_srpms
+from guanfu.koji_rebuild.container_executor import (
+    build_container_command,
+    container_executor_summary,
+    default_container_image,
+    detect_target_os,
+    environment_executor_summary,
+    is_supported_target_os,
+    run_container_command,
+    select_container_runtime,
+)
 from guanfu.koji_rebuild.downloader import (
     download_task_output,
     join_url,
     summarize_file,
     try_download_url,
 )
-from guanfu.koji_rebuild.mock_config import generate_mock_config, probe_repodata
+from guanfu.koji_rebuild.mock_config import enforce_nonroot_mock_build_user, generate_mock_config, probe_repodata
 from guanfu.koji_rebuild.mock_runner import run_rebuild
 from guanfu.koji_rebuild.report import write_json
+from guanfu.koji_rebuild.repo_fallback import (
+    prepare_installed_pkgs_fallback,
+    summarize_fallback_report,
+)
 from guanfu.koji_rebuild.resolver import resolve_koji_build
 from guanfu.koji_rebuild.rpm_name import parse_rpm_filename, rpm_filename
 
@@ -91,9 +106,17 @@ def _srpm_cross_check_summary(cross_check):
     }
 
 
-def _build_environment_summary(args, resolution=None, repo_probe=None, mock_cfg=None):
+def _build_environment_summary(
+    args,
+    resolution=None,
+    repo_probe=None,
+    mock_cfg=None,
+    repo_fallback=None,
+    executor=None,
+):
     buildroot = resolution.buildroot if resolution else {}
     environment = {
+        "executor": executor or environment_executor_summary(args),
         "koji_server": args.koji_server,
         "koji_topurl": args.koji_topurl,
         "buildroot_id": buildroot.get("id"),
@@ -105,6 +128,8 @@ def _build_environment_summary(args, resolution=None, repo_probe=None, mock_cfg=
     }
     if mock_cfg:
         environment["mock_config"] = _public_artifact(summarize_file(mock_cfg))
+    if repo_fallback:
+        environment["repo_fallback"] = summarize_fallback_report(repo_fallback)
     return _without_none(environment)
 
 
@@ -122,16 +147,42 @@ def _rebuild_summary(args, status, rebuilds=None, repeatable=None, reason=None, 
     if repeatable is not None:
         summary["repeatable_by_rpm_sha256"] = repeatable
     if rebuilds:
+        diagnosis = _first_failure_diagnosis(rebuilds)
+        if diagnosis:
+            summary["failure_diagnosis"] = diagnosis
         summary["runs_detail"] = [
-            {
-                "run": item.get("run"),
-                "exit_code": item.get("exit_code"),
-                "elapsed_seconds": item.get("elapsed_seconds"),
-                "rpms": [_public_artifact(rpm) for rpm in item.get("rpms", [])],
-            }
+            _without_none(
+                {
+                    "run": item.get("run"),
+                    "exit_code": item.get("exit_code"),
+                    "elapsed_seconds": item.get("elapsed_seconds"),
+                    "rpms": [_public_artifact(rpm) for rpm in item.get("rpms", [])],
+                    "failure_diagnosis": item.get("failure_diagnosis"),
+                }
+            )
             for item in rebuilds
         ]
     return summary
+
+
+def _first_failure_diagnosis(rebuilds):
+    for item in rebuilds or []:
+        diagnosis = item.get("failure_diagnosis")
+        if diagnosis:
+            return diagnosis
+    return None
+
+
+def _print_rebuild_failure_diagnosis(result):
+    diagnosis = result.get("failure_diagnosis")
+    if not diagnosis:
+        return
+    print(f"[guanfu] Mock failure diagnosis: {diagnosis.get('summary')}", file=sys.stderr)
+    print(f"[guanfu] Suggested action: {diagnosis.get('suggested_action')}", file=sys.stderr)
+    evidence = diagnosis.get("evidence") or []
+    if evidence:
+        item = evidence[0]
+        print(f"[guanfu] Evidence: {item.get('log')}: {item.get('line')}", file=sys.stderr)
 
 
 def _unavailable_assessment(field, confidence=0.9):
@@ -182,6 +233,129 @@ def _analysis_summary():
     }
 
 
+def _prepare_mock_config_for_execution(mock_cfg):
+    if os.environ.get("GUANFU_EXECUTOR_MODE") == "container" and os.environ.get("GUANFU_IN_CONTAINER") == "1":
+        enforce_nonroot_mock_build_user(mock_cfg)
+    return mock_cfg
+
+
+def _find_report_paths(workdir, rpm_name):
+    base = Path(workdir).expanduser().resolve() / _safe_name(Path(rpm_name).name)
+    if not base.exists():
+        return []
+    return sorted(base.glob("**/report.json"))
+
+
+def _write_preflight_report(args, status, reason, resolution=None, executor=None, error=None, assessment_field=None):
+    run_dir = _run_dir(args.workdir, args.rpm_name)
+    target_name = rpm_filename(resolution.rpm) if resolution else args.rpm_name
+    report = {
+        "version": ASSESSMENT_VERSION,
+        "metadata": {
+            "package_name": target_name,
+            "analysis_time": _analysis_time(),
+        },
+        "input_artifacts": {},
+        "build_environment": _build_environment_summary(
+            args,
+            resolution=resolution,
+            executor=executor,
+        ),
+        "rebuild": _rebuild_summary(args, status, reason=reason, error=error),
+        "analysis": _analysis_summary(),
+    }
+    if assessment_field:
+        report.update(_unavailable_assessment(assessment_field))
+    write_json(run_dir / "report.json", report)
+    return run_dir / "report.json"
+
+
+def _run_containerized_koji_rpm_rebuild(args):
+    try:
+        rpm_info = parse_rpm_filename(args.rpm_name)
+        client = KojiClient(args.koji_server)
+        resolution = resolve_koji_build(client, rpm_info)
+        target_os = detect_target_os(rpm_info, resolution.buildroot)
+    except Exception as exc:
+        report_path = _write_preflight_report(
+            args,
+            "error",
+            "container executor preflight failed",
+            error=repr(exc),
+            assessment_field="container_preflight",
+        )
+        print(f"[guanfu] Container preflight failed: {exc}", file=sys.stderr)
+        print(f"[guanfu] Partial report: {report_path}", file=sys.stderr)
+        return 1
+
+    if not is_supported_target_os(target_os):
+        executor = container_executor_summary(target_os=target_os)
+        report_path = _write_preflight_report(
+            args,
+            "unsupported",
+            "only an23 Koji RPM rebuild is currently supported by the container executor",
+            resolution=resolution,
+            executor=executor,
+            assessment_field="unsupported_target",
+        )
+        print(
+            "[guanfu] Unsupported Koji RPM target for container executor: "
+            f"tag={resolution.buildroot.get('tag_name')!r}",
+            file=sys.stderr,
+        )
+        print(f"[guanfu] Partial report: {report_path}", file=sys.stderr)
+        return 3
+
+    image = getattr(args, "container_image", None) or default_container_image(target_os)
+    try:
+        runtime = select_container_runtime(getattr(args, "container_runtime", "auto"))
+    except Exception as exc:
+        executor = container_executor_summary(
+            image=image,
+            target_os=target_os,
+            privileged=getattr(args, "container_privileged", True),
+        )
+        report_path = _write_preflight_report(
+            args,
+            "error",
+            "container runtime is not available",
+            resolution=resolution,
+            executor=executor,
+            error=repr(exc),
+            assessment_field="container_runtime",
+        )
+        print(f"[guanfu] Container runtime is not available: {exc}", file=sys.stderr)
+        print(f"[guanfu] Partial report: {report_path}", file=sys.stderr)
+        return 2
+
+    workdir = Path(args.workdir).expanduser().resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+    command = build_container_command(args, runtime, image, workdir)
+    before_reports = set(_find_report_paths(workdir, args.rpm_name))
+    exit_code = run_container_command(command)
+    after_reports = set(_find_report_paths(workdir, args.rpm_name))
+
+    if exit_code != 0 and after_reports == before_reports:
+        executor = container_executor_summary(
+            runtime=runtime,
+            image=image,
+            target_os=target_os,
+            privileged=getattr(args, "container_privileged", True),
+            command=command,
+        )
+        report_path = _write_preflight_report(
+            args,
+            "error",
+            "container executor did not produce a rebuild report",
+            resolution=resolution,
+            executor=executor,
+            error=f"container command exited with code {exit_code}",
+            assessment_field="container_executor",
+        )
+        print(f"[guanfu] Container executor did not produce a report: {report_path}", file=sys.stderr)
+    return exit_code
+
+
 def _input_artifacts_summary(
     published_rpm_summary=None,
     task_srpm_summary=None,
@@ -230,6 +404,13 @@ def run_koji_rpm_rebuild(args):
         print("--runs must be >= 1", file=sys.stderr)
         return 2
 
+    executor = getattr(args, "executor", "local")
+    if executor == "container" and os.environ.get("GUANFU_IN_CONTAINER") == "1":
+        executor = "local"
+        args.executor = "local"
+    if executor == "container":
+        return _run_containerized_koji_rpm_rebuild(args)
+
     run_dir = _run_dir(args.workdir, args.rpm_name)
     inputs_dir = run_dir / "inputs"
     results_dir = run_dir / "results"
@@ -264,23 +445,6 @@ def run_koji_rpm_rebuild(args):
 
         repo_probe = probe_repodata(args.koji_topurl, resolution.buildroot)
         write_json(metadata_dir / "repo-probe.json", repo_probe)
-        if repo_probe.get("status") != 200:
-            report["metadata"]["package_name"] = target_rpm_name
-            report["metadata"]["analysis_time"] = _analysis_time()
-            report["build_environment"] = _build_environment_summary(
-                args,
-                resolution=resolution,
-                repo_probe=repo_probe,
-            )
-            report["rebuild"] = _rebuild_summary(
-                args,
-                "skipped",
-                reason="original buildroot repo repomd.xml is not available",
-            )
-            report.update(_unavailable_assessment("historical_repo"))
-            write_json(run_dir / "report.json", report)
-            print(f"[guanfu] Historical repo is not available: {repo_probe.get('url')}", file=sys.stderr)
-            return 3
 
         published_rpm_url = join_url(args.binary_rpm_base_url, target_rpm_name)
         published_rpm, published_rpm_summary = _download_published(
@@ -330,14 +494,156 @@ def run_koji_rpm_rebuild(args):
             resolution.buildroot["id"],
             mock_cfg,
         )
+        _prepare_mock_config_for_execution(mock_cfg)
+        active_mock_cfg = mock_cfg
+        repo_fallback = None
+
+        if repo_probe.get("status") != 200:
+            if getattr(args, "repo_fallback", "installed-pkgs") == "none":
+                report = {
+                    "version": ASSESSMENT_VERSION,
+                    "metadata": {
+                        "package_name": target_rpm_name,
+                        "reference_url": published_rpm_url,
+                        "reference_sha256": published_rpm_summary.get("sha256"),
+                        "rebuild_sha256": None,
+                        "analysis_time": _analysis_time(),
+                    },
+                    "input_artifacts": _input_artifacts_summary(
+                        published_rpm_summary=published_rpm_summary,
+                        task_srpm_summary=task_srpm_summary,
+                        log_summaries=log_summaries,
+                        source_rpm_summary=source_rpm_summary,
+                        source_rpm_type=source_rpm_type,
+                        source_rpm_url=source_rpm_url,
+                        task_id=resolution.buildarch_task["id"],
+                        srpm_cross_check=srpm_cross_check,
+                    ),
+                    "build_environment": _build_environment_summary(
+                        args,
+                        resolution=resolution,
+                        repo_probe=repo_probe,
+                        mock_cfg=mock_cfg,
+                    ),
+                    "rebuild": _rebuild_summary(
+                        args,
+                        "skipped",
+                        reason="original buildroot repo repomd.xml is not available",
+                    ),
+                    "analysis": _analysis_summary(),
+                }
+                report.update(_unavailable_assessment("historical_repo"))
+                write_json(run_dir / "report.json", report)
+                print(f"[guanfu] Historical repo is not available: {repo_probe.get('url')}", file=sys.stderr)
+                return 3
+
+            installed_pkgs_log = inputs_dir / "installed_pkgs.log"
+            if not installed_pkgs_log.exists():
+                repo_fallback = {
+                    "strategy": "installed_pkgs_log",
+                    "status": "unavailable",
+                    "source_task_id": resolution.buildarch_task["id"],
+                    "dependency_recovery": {
+                        "total": 0,
+                        "resolved_by_getRPM": 0,
+                        "unresolved": 0,
+                        "payloadhash_mismatch": 0,
+                        "task_output_available": 0,
+                        "missing_task_output": 0,
+                        "downloaded": 0,
+                        "download_errors": 0,
+                    },
+                    "error": "installed_pkgs.log was not found in Koji task output",
+                }
+            else:
+                try:
+                    repo_fallback = prepare_installed_pkgs_fallback(
+                        client,
+                        resolution.buildroot,
+                        installed_pkgs_log,
+                        mock_cfg,
+                        inputs_dir / "mock-fallback-installed-pkgs.cfg",
+                        run_dir / "fallback-repo",
+                        metadata_dir,
+                        resolution.buildarch_task["id"],
+                    )
+                except Exception as exc:
+                    repo_fallback = {
+                        "strategy": "installed_pkgs_log",
+                        "status": "error",
+                        "source_task_id": resolution.buildarch_task["id"],
+                        "installed_pkgs_log": _public_artifact(
+                            summarize_file(installed_pkgs_log),
+                            source_type="koji_task_output",
+                            task_id=resolution.buildarch_task["id"],
+                        ),
+                        "dependency_recovery": {
+                            "total": 0,
+                            "resolved_by_getRPM": 0,
+                            "unresolved": 0,
+                            "payloadhash_mismatch": 0,
+                            "task_output_available": 0,
+                            "missing_task_output": 0,
+                            "downloaded": 0,
+                            "download_errors": 0,
+                        },
+                        "error": repr(exc),
+                    }
+            write_json(metadata_dir / "repo-fallback.json", repo_fallback)
+
+            if repo_fallback.get("status") != "ready":
+                report = {
+                    "version": ASSESSMENT_VERSION,
+                    "metadata": {
+                        "package_name": target_rpm_name,
+                        "reference_url": published_rpm_url,
+                        "reference_sha256": published_rpm_summary.get("sha256"),
+                        "rebuild_sha256": None,
+                        "analysis_time": _analysis_time(),
+                    },
+                    "input_artifacts": _input_artifacts_summary(
+                        published_rpm_summary=published_rpm_summary,
+                        task_srpm_summary=task_srpm_summary,
+                        log_summaries=log_summaries,
+                        source_rpm_summary=source_rpm_summary,
+                        source_rpm_type=source_rpm_type,
+                        source_rpm_url=source_rpm_url,
+                        task_id=resolution.buildarch_task["id"],
+                        srpm_cross_check=srpm_cross_check,
+                    ),
+                    "build_environment": _build_environment_summary(
+                        args,
+                        resolution=resolution,
+                        repo_probe=repo_probe,
+                        mock_cfg=mock_cfg,
+                        repo_fallback=repo_fallback,
+                    ),
+                    "rebuild": _rebuild_summary(
+                        args,
+                        "skipped",
+                        reason="historical repo is unavailable and installed_pkgs fallback is incomplete",
+                    ),
+                    "analysis": _analysis_summary(),
+                }
+                report.update(_unavailable_assessment("dependency_recovery"))
+                write_json(run_dir / "report.json", report)
+                print(
+                    "[guanfu] Historical repo is not available and installed_pkgs fallback is incomplete",
+                    file=sys.stderr,
+                )
+                return 3
+
+            active_mock_cfg = inputs_dir / "mock-fallback-installed-pkgs.cfg"
+            _prepare_mock_config_for_execution(active_mock_cfg)
 
         rebuilds = []
         for run_index in range(1, args.runs + 1):
             resultdir = results_dir / f"result-run-{run_index}"
-            result = run_rebuild(mock_cfg, srpm_for_rebuild, resultdir, isolation=args.isolation)
+            result = run_rebuild(active_mock_cfg, srpm_for_rebuild, resultdir, isolation=args.isolation)
             result["run"] = run_index
             rebuilds.append(result)
             if result["exit_code"] != 0:
+                _print_rebuild_failure_diagnosis(result)
                 break
 
         successful = rebuilds and all(item["exit_code"] == 0 for item in rebuilds)
@@ -374,7 +680,8 @@ def run_koji_rpm_rebuild(args):
                     args,
                     resolution=resolution,
                     repo_probe=repo_probe,
-                    mock_cfg=mock_cfg,
+                    mock_cfg=active_mock_cfg,
+                    repo_fallback=repo_fallback,
                 ),
                 "rebuild": _rebuild_summary(
                     args,
@@ -411,7 +718,8 @@ def run_koji_rpm_rebuild(args):
                     args,
                     resolution=resolution,
                     repo_probe=repo_probe,
-                    mock_cfg=mock_cfg,
+                    mock_cfg=active_mock_cfg,
+                    repo_fallback=repo_fallback,
                 ),
                 "rebuild": _rebuild_summary(args, "failed", rebuilds=rebuilds),
                 "analysis": _analysis_summary(),

--- a/src/guanfu/koji_rebuild/container_executor.py
+++ b/src/guanfu/koji_rebuild/container_executor.py
@@ -1,0 +1,147 @@
+import os
+import platform
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+DEFAULT_AN23_CONTAINER_IMAGE = "ghcr.io/1570005763/guanfu-koji-rebuild-an23:latest"
+CONTAINER_WORKDIR = "/work"
+
+
+def detect_target_os(rpm_info=None, buildroot=None):
+    tag = ((buildroot or {}).get("tag_name") or "").lower()
+    release = ((rpm_info or {}).get("release") or "").lower()
+    if _has_an23_marker(tag) or _has_an23_marker(release):
+        return "an23"
+    return None
+
+
+def is_supported_target_os(target_os):
+    return target_os == "an23"
+
+
+def default_container_image(target_os):
+    if target_os == "an23":
+        return os.environ.get("GUANFU_AN23_CONTAINER_IMAGE", DEFAULT_AN23_CONTAINER_IMAGE)
+    return None
+
+
+def select_container_runtime(requested="auto"):
+    requested = requested or "auto"
+    if requested != "auto":
+        if shutil.which(requested):
+            return requested
+        raise RuntimeError(f"container runtime was not found: {requested}")
+
+    order = ["podman", "docker"] if platform.system().lower() == "linux" else ["docker", "podman"]
+    for runtime in order:
+        if shutil.which(runtime):
+            return runtime
+    raise RuntimeError("container runtime was not found: tried podman and docker")
+
+
+def build_container_command(args, runtime, image, host_workdir):
+    host_workdir = Path(host_workdir).expanduser().resolve()
+    command = [runtime, "run", "--rm"]
+    if getattr(args, "container_privileged", True):
+        command.append("--privileged")
+    command.extend(
+        [
+            "-v",
+            f"{host_workdir}:{CONTAINER_WORKDIR}",
+            "-w",
+            CONTAINER_WORKDIR,
+            "-e",
+            "GUANFU_IN_CONTAINER=1",
+            "-e",
+            "GUANFU_EXECUTOR_MODE=container",
+            "-e",
+            f"GUANFU_CONTAINER_RUNTIME={runtime}",
+            "-e",
+            f"GUANFU_CONTAINER_IMAGE={image}",
+            "-e",
+            f"GUANFU_CONTAINER_PRIVILEGED={str(getattr(args, 'container_privileged', True)).lower()}",
+            "-e",
+            "GUANFU_TARGET_OS=an23",
+            image,
+            "guanfu",
+            "rebuild",
+            "koji-rpm",
+            "--rpm-name",
+            args.rpm_name,
+            "--executor",
+            "local",
+            "--koji-server",
+            args.koji_server,
+            "--koji-topurl",
+            args.koji_topurl,
+            "--binary-rpm-base-url",
+            args.binary_rpm_base_url,
+            "--source-rpm-base-url",
+            args.source_rpm_base_url,
+            "--workdir",
+            CONTAINER_WORKDIR,
+            "--runs",
+            str(args.runs),
+            "--isolation",
+            args.isolation,
+            "--repo-fallback",
+            args.repo_fallback,
+        ]
+    )
+    return command
+
+
+def run_container_command(command):
+    return subprocess.run(command).returncode
+
+
+def container_executor_summary(runtime=None, image=None, target_os=None, privileged=None, command=None):
+    summary = {
+        "mode": "container",
+        "target_os": target_os,
+        "container_runtime": runtime,
+        "container_image": image,
+        "privileged": privileged,
+        "workdir_in_container": CONTAINER_WORKDIR,
+    }
+    if command:
+        summary["command"] = command
+    return _without_none(summary)
+
+
+def environment_executor_summary(args):
+    if os.environ.get("GUANFU_EXECUTOR_MODE") == "container":
+        return _without_none(
+            {
+                "mode": "container",
+                "inside_container": os.environ.get("GUANFU_IN_CONTAINER") == "1",
+                "target_os": os.environ.get("GUANFU_TARGET_OS"),
+                "container_runtime": os.environ.get("GUANFU_CONTAINER_RUNTIME"),
+                "container_image": os.environ.get("GUANFU_CONTAINER_IMAGE"),
+                "privileged": _parse_bool(os.environ.get("GUANFU_CONTAINER_PRIVILEGED")),
+                "workdir_in_container": CONTAINER_WORKDIR,
+            }
+        )
+    return {
+        "mode": getattr(args, "executor", "local"),
+        "inside_container": os.environ.get("GUANFU_IN_CONTAINER") == "1",
+    }
+
+
+def _has_an23_marker(value):
+    if not value:
+        return False
+    return bool(re.search(r"(^|[^a-z0-9])an23([^a-z0-9]|$)", value))
+
+
+def _parse_bool(value):
+    if value is None:
+        return None
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def _without_none(data):
+    return dict((key, value) for key, value in data.items() if value is not None)

--- a/src/guanfu/koji_rebuild/mock_config.py
+++ b/src/guanfu/koji_rebuild/mock_config.py
@@ -1,7 +1,11 @@
+import re
 import subprocess
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+
+CONTAINER_MOCKBUILD_UID = 1000
 
 
 def historical_repo_url(koji_topurl, buildroot):
@@ -40,3 +44,28 @@ def generate_mock_config(koji_server, koji_topurl, buildroot_id, dest):
     ]
     subprocess.run(cmd, check=True)
     return dest
+
+
+def enforce_nonroot_mock_build_user(
+    mock_cfg,
+    uid=CONTAINER_MOCKBUILD_UID,
+):
+    """Keep rpmbuild/%check from running as root inside containerized mock."""
+    mock_cfg = Path(mock_cfg)
+    text = mock_cfg.read_text()
+    text = _upsert_config_opt(text, "chrootuid", uid)
+    mock_cfg.write_text(text)
+    return mock_cfg
+
+
+def _upsert_config_opt(text, key, value):
+    line = f"config_opts['{key}'] = {value}"
+    pattern = r"(?m)^config_opts\[['\"]%s['\"]\]\s*=.*$" % key
+    replaced, count = re.subn(pattern, line, text)
+    if count:
+        return replaced
+    if not text.endswith("\n"):
+        text += "\n"
+    if "# GuanFu container mock user override." not in text:
+        text += "\n# GuanFu container mock user override.\n"
+    return text + line + "\n"

--- a/src/guanfu/koji_rebuild/mock_runner.py
+++ b/src/guanfu/koji_rebuild/mock_runner.py
@@ -1,8 +1,20 @@
+import os
 import subprocess
 import time
 from pathlib import Path
 
 from guanfu.koji_rebuild.downloader import summarize_file
+
+_LOG_FILES = ("root.log", "build.log", "state.log")
+_LOG_TAIL_BYTES = 128 * 1024
+_RUNTIME_CRASH_MARKERS = (
+    "scriptlet failed, signal 11",
+    "scriptlet failed, signal 4",
+    "segmentation fault",
+    "segfault",
+    "illegal instruction",
+    "invalid opcode",
+)
 
 
 def _list_result_rpms(resultdir):
@@ -12,6 +24,8 @@ def _list_result_rpms(resultdir):
 def run_rebuild(mock_cfg, srpm, resultdir, isolation="simple"):
     resultdir = Path(resultdir)
     resultdir.mkdir(parents=True, exist_ok=True)
+    if os.environ.get("GUANFU_EXECUTOR_MODE") == "container" and os.environ.get("GUANFU_IN_CONTAINER") == "1":
+        resultdir.chmod(0o777)
     started = time.time()
     cmd = [
         "mock",
@@ -25,9 +39,59 @@ def run_rebuild(mock_cfg, srpm, resultdir, isolation="simple"):
     ]
     proc = subprocess.run(cmd)
     elapsed = time.time() - started
-    return {
+    result = {
         "exit_code": proc.returncode,
         "elapsed_seconds": round(elapsed, 1),
         "command": cmd,
         "rpms": [summarize_file(path) for path in _list_result_rpms(resultdir)],
     }
+    if proc.returncode != 0:
+        diagnosis = _diagnose_mock_failure(resultdir)
+        if diagnosis:
+            result["failure_diagnosis"] = diagnosis
+    return result
+
+
+def _diagnose_mock_failure(resultdir):
+    evidence = _runtime_crash_evidence(resultdir)
+    if not evidence:
+        return None
+    return {
+        "category": "buildroot_runtime_incompatible",
+        "confidence": 0.85,
+        "summary": (
+            "mock failed while executing programs or RPM scriptlets inside the buildroot. "
+            "This can be caused by old buildroot userland being incompatible with the "
+            "current host/container CPU or kernel execution environment."
+        ),
+        "suggested_action": (
+            "Retry the same GuanFu command inside a Linux VM with a controlled CPU model "
+            "close to the Koji builder. Container and local executors still share the "
+            "host kernel/CPU exposure, so a VM may fix this class of failure."
+        ),
+        "evidence": evidence,
+    }
+
+
+def _runtime_crash_evidence(resultdir):
+    resultdir = Path(resultdir)
+    evidence = []
+    for log_name in _LOG_FILES:
+        log_path = resultdir / log_name
+        if not log_path.exists():
+            continue
+        for line in _read_tail(log_path).splitlines():
+            lowered = line.lower()
+            if any(marker in lowered for marker in _RUNTIME_CRASH_MARKERS):
+                evidence.append({"log": log_name, "line": line.strip()})
+                if len(evidence) >= 3:
+                    return evidence
+    return evidence
+
+
+def _read_tail(path):
+    with Path(path).open("rb") as handle:
+        handle.seek(0, 2)
+        size = handle.tell()
+        handle.seek(max(0, size - _LOG_TAIL_BYTES))
+        return handle.read().decode(errors="replace")

--- a/src/guanfu/koji_rebuild/repo_fallback.py
+++ b/src/guanfu/koji_rebuild/repo_fallback.py
@@ -1,0 +1,890 @@
+import bz2
+import gzip
+import lzma
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from guanfu.koji_rebuild.downloader import download_task_output, download_url, summarize_file
+from guanfu.koji_rebuild.rpm_name import rpm_filename
+
+
+def _strip_epoch_from_nevra(nevra):
+    return re.sub(r"(?<=-)\d+:", "", nevra)
+
+
+def parse_installed_pkgs(path):
+    entries = []
+    for line_number, line in enumerate(Path(path).read_text(errors="replace").splitlines(), 1):
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+        nevra = parts[0]
+        entries.append(
+            {
+                "line": line_number,
+                "nevra": nevra,
+                "rpm_lookup": _strip_epoch_from_nevra(nevra),
+                "buildtime": parts[1],
+                "installed_size": parts[2],
+                "payloadhash": parts[3],
+                "state": parts[4],
+            }
+        )
+    return entries
+
+
+def _parse_nevra(nevra):
+    try:
+        nvr, arch = nevra.rsplit(".", 1)
+        nv, release = nvr.rsplit("-", 1)
+        name, version = nv.rsplit("-", 1)
+    except ValueError as exc:
+        raise ValueError(f"Cannot parse NEVRA: {nevra}") from exc
+    return {"name": name, "version": version, "release": release, "arch": arch}
+
+
+def _rpm_filename_from_nevra(nevra):
+    return "%s.rpm" % nevra
+
+
+def _replace_repo_arch(url, arch):
+    return url.replace("$arch", arch).replace("${arch}", arch).replace("$basearch", arch)
+
+
+def _url_join(base, href):
+    if not base.endswith("/"):
+        base += "/"
+    return urllib.parse.urljoin(base, href)
+
+
+def _download_metadata(url, dest):
+    path = download_url(url, dest)
+    return summarize_file(path, label="external_repo_metadata", url=url)
+
+
+def _open_metadata(path):
+    path = Path(path)
+    name = path.name
+    if name.endswith(".gz"):
+        return gzip.open(path, "rb")
+    if name.endswith(".bz2"):
+        return bz2.open(path, "rb")
+    if name.endswith(".xz"):
+        return lzma.open(path, "rb")
+    return path.open("rb")
+
+
+def _local_name(element):
+    return element.tag.rsplit("}", 1)[-1]
+
+
+def _find_primary_location(repomd_path):
+    tree = ET.parse(repomd_path)
+    for data in tree.getroot():
+        if _local_name(data) != "data" or data.get("type") != "primary":
+            continue
+        location = None
+        checksum = None
+        open_checksum = None
+        for child in data:
+            name = _local_name(child)
+            if name == "location":
+                location = child.get("href")
+            elif name == "checksum":
+                checksum = {"type": child.get("type"), "value": child.text}
+            elif name == "open-checksum":
+                open_checksum = {"type": child.get("type"), "value": child.text}
+        if location:
+            return {"href": location, "checksum": checksum, "open_checksum": open_checksum}
+    raise RuntimeError("external repo repomd.xml does not contain primary metadata")
+
+
+def _parse_primary_packages(primary_path):
+    with _open_metadata(primary_path) as metadata:
+        for _, package in ET.iterparse(metadata, events=("end",)):
+            if _local_name(package) != "package" or package.get("type") != "rpm":
+                continue
+            item = {}
+            for child in package:
+                name = _local_name(child)
+                if name == "name":
+                    item["name"] = child.text
+                elif name == "arch":
+                    item["arch"] = child.text
+                elif name == "version":
+                    item["epoch"] = child.get("epoch")
+                    item["version"] = child.get("ver")
+                    item["release"] = child.get("rel")
+                elif name == "checksum":
+                    item["checksum"] = {"type": child.get("type"), "value": child.text}
+                elif name == "location":
+                    item["href"] = child.get("href")
+                elif name == "size":
+                    item["package_size"] = child.get("package")
+                    item["installed_size"] = child.get("installed")
+                    item["archive_size"] = child.get("archive")
+                elif name == "time":
+                    item["file_time"] = child.get("file")
+                    item["buildtime"] = child.get("build")
+            yield item
+            package.clear()
+
+
+def _rpm_query(path):
+    query = (
+        "NAME=%{NAME}\\n"
+        "VERSION=%{VERSION}\\n"
+        "RELEASE=%{RELEASE}\\n"
+        "ARCH=%{ARCH}\\n"
+        "BUILDTIME=%{BUILDTIME}\\n"
+        "SIZE=%{SIZE}\\n"
+        "SIGMD5=%{SIGMD5}\\n"
+        "SOURCERPM=%{SOURCERPM}\\n"
+        "VENDOR=%{VENDOR}\\n"
+        "PACKAGER=%{PACKAGER}\\n"
+    )
+    proc = subprocess.run(
+        ["rpm", "-qp", "--qf", query, str(path)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    result = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            result[key.lower()] = value
+    return result
+
+
+def _verify_external_rpm(path, entry):
+    expected = _parse_nevra(entry["rpm_lookup"])
+    header = _rpm_query(path)
+    checks = {
+        "nevra": all(
+            str(header.get(key)) == str(expected[key])
+            for key in ("name", "version", "release", "arch")
+        ),
+        "sigmd5": str(header.get("sigmd5", "")).lower() == str(entry.get("payloadhash", "")).lower(),
+        "size": str(header.get("size")) == str(entry.get("installed_size")),
+        "buildtime": str(header.get("buildtime")) == str(entry.get("buildtime")),
+    }
+    return {
+        "checks": checks,
+        "matched": all(checks.values()),
+        "rpm_header": header,
+    }
+
+
+def _task_output_has_file(outputs, filename):
+    if isinstance(outputs, dict):
+        return filename in outputs
+    return filename in (outputs or [])
+
+
+def _find_task_output(client, build_task_id, filename, cache):
+    if build_task_id in cache:
+        task_outputs = cache[build_task_id]
+    else:
+        task_outputs = []
+        try:
+            task_outputs.append((build_task_id, client.list_task_output(build_task_id)))
+        except Exception:
+            pass
+        for child in client.get_task_children(build_task_id):
+            task_id = child.get("id")
+            if task_id is None:
+                continue
+            try:
+                task_outputs.append((task_id, client.list_task_output(task_id)))
+            except Exception:
+                continue
+        cache[build_task_id] = task_outputs
+
+    for task_id, outputs in task_outputs:
+        if _task_output_has_file(outputs, filename):
+            return task_id
+    return None
+
+
+def _download_dependency(client, task_id, filename, repo_dir):
+    path = Path(repo_dir) / filename
+    if path.exists() and path.stat().st_size > 0:
+        return summarize_file(path, label="recovered_dependency_rpm")
+    download_task_output(client, task_id, filename, path)
+    return summarize_file(path, label="recovered_dependency_rpm")
+
+
+def _repo_event(buildroot):
+    return buildroot.get("repo_create_event_id") or buildroot.get("create_event_id")
+
+
+def _external_repo_metadata(client, buildroot, metadata_dir):
+    event = _repo_event(buildroot)
+    repos = client.get_external_repo_list(buildroot["tag_name"], event)
+    arch = buildroot["arch"]
+    metadata = []
+    for index, repo in enumerate(repos or []):
+        base_url = _replace_repo_arch(repo["url"], arch)
+        repo_dir = Path(metadata_dir) / "external-repos" / ("%02d-%s" % (index, repo["external_repo_name"]))
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        item = dict(repo)
+        item["event_id"] = event
+        item["resolved_url"] = base_url
+        try:
+            repomd_url = _url_join(base_url, "repodata/repomd.xml")
+            repomd = _download_metadata(repomd_url, repo_dir / "repomd.xml")
+            primary_info = _find_primary_location(repo_dir / "repomd.xml")
+            primary_url = _url_join(base_url, primary_info["href"])
+            primary = _download_metadata(primary_url, repo_dir / Path(primary_info["href"]).name)
+            item["repomd"] = repomd
+            item["primary"] = primary
+            item["primary_info"] = primary_info
+            item["status"] = "ready"
+        except Exception as exc:
+            item["status"] = "error"
+            item["error"] = repr(exc)
+        metadata.append(item)
+    return metadata
+
+
+def _find_external_package(repo_metadata, entry):
+    expected = _parse_nevra(entry["rpm_lookup"])
+    for repo in repo_metadata:
+        if repo.get("status") != "ready":
+            continue
+        for package in _parse_primary_packages(repo["primary"]["path"]):
+            if all(
+                str(package.get(key)) == str(expected[key])
+                for key in ("name", "version", "release", "arch")
+            ):
+                return repo, package
+    return None, None
+
+
+def _recover_external_rpms(client, buildroot, entries, repo_dir, metadata_dir):
+    repo_metadata = _external_repo_metadata(client, buildroot, metadata_dir)
+    report = {
+        "status": "ready",
+        "event_id": _repo_event(buildroot),
+        "repos": repo_metadata,
+        "resolved": [],
+        "unresolved": [],
+        "verification_failed": [],
+        "download_errors": [],
+    }
+    recovered = []
+    downloaded_cache = {}
+    for entry in entries:
+        repo, package = _find_external_package(repo_metadata, entry)
+        if not package:
+            report["unresolved"].append(entry)
+            continue
+
+        source_url = _url_join(repo["resolved_url"], package["href"])
+        filename = Path(package["href"]).name or _rpm_filename_from_nevra(entry["rpm_lookup"])
+        path = Path(repo_dir) / filename
+        artifact = downloaded_cache.get(source_url)
+        if artifact is None:
+            try:
+                download_url(source_url, path)
+                artifact = summarize_file(path, label="recovered_external_rpm", url=source_url)
+                artifact["source_type"] = "external_repo"
+                artifact["external_repo_name"] = repo["external_repo_name"]
+                artifact["repo_checksum"] = package.get("checksum")
+                downloaded_cache[source_url] = artifact
+            except Exception as exc:
+                report["download_errors"].append(
+                    {
+                        "nevra": entry["nevra"],
+                        "url": source_url,
+                        "error": repr(exc),
+                    }
+                )
+                continue
+
+        verification = _verify_external_rpm(path, entry)
+        item = {
+            "entry": entry,
+            "source_type": "external_repo",
+            "external_repo_name": repo["external_repo_name"],
+            "source_url": source_url,
+            "filename": filename,
+            "artifact": artifact,
+            "package_metadata": package,
+            "verification": verification,
+        }
+        if not verification["matched"]:
+            report["verification_failed"].append(
+                {
+                    "nevra": entry["nevra"],
+                    "url": source_url,
+                    "verification": verification,
+                }
+            )
+            continue
+        report["resolved"].append(
+            {
+                "nevra": entry["nevra"],
+                "rpm_lookup": entry["rpm_lookup"],
+                "source_repo": repo["external_repo_name"],
+                "url": source_url,
+                "verification": verification,
+                "artifact": artifact,
+            }
+        )
+        recovered.append(item)
+
+    if report["unresolved"] or report["verification_failed"] or report["download_errors"]:
+        report["status"] = "incomplete"
+    return recovered, report
+
+
+def _write_comps(entries, dest):
+    names = sorted(set(entry["name"] for entry in entries))
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">',
+        "<comps>",
+        "  <group>",
+        "    <id>build</id>",
+        "    <name>build</name>",
+        "    <description>Reconstructed Koji buildroot package group</description>",
+        "    <default>true</default>",
+        "    <uservisible>false</uservisible>",
+        "    <packagelist>",
+    ]
+    for name in names:
+        lines.append('      <packagereq type="default">%s</packagereq>' % escape(name))
+    lines.extend(
+        [
+            "    </packagelist>",
+            "  </group>",
+            "</comps>",
+        ]
+    )
+    Path(dest).write_text("\n".join(lines) + "\n")
+
+
+def _run_createrepo(repo_dir, comps_xml):
+    createrepo = shutil.which("createrepo_c") or shutil.which("createrepo")
+    if not createrepo:
+        raise RuntimeError("createrepo_c or createrepo is required for installed_pkgs fallback")
+    cmd = [createrepo, "-q", "-g", str(comps_xml), str(repo_dir)]
+    subprocess.run(cmd, check=True)
+
+
+def _load_mock_config_values(mock_cfg):
+    defaults = {
+        "package_manager": "dnf",
+        "use_bootstrap": True,
+        "use_bootstrap_image": True,
+        "dnf4_install_command": "install python3-dnf python3-dnf-plugins-core",
+        "dnf5_install_command": "install dnf5 dnf5-plugins",
+        "yum_install_command": "install yum yum-utils",
+        "microdnf_install_command": "dnf-install microdnf dnf dnf-plugins-core",
+        "bootstrap_chroot_additional_packages": [],
+    }
+    try:
+        from mockbuild.config import setup_default_config_opts, update_config_from_file
+
+        config_opts = setup_default_config_opts()
+        update_config_from_file(config_opts, str(mock_cfg))
+        source = "mockbuild_config"
+    except Exception as exc:
+        config_opts = dict(defaults)
+        config_opts["plugin_conf"] = {}
+        config_opts["macros"] = {}
+        source = "fallback_default"
+        try:
+            exec(compile(Path(mock_cfg).read_text(), str(mock_cfg), "exec"), {"config_opts": config_opts})
+            source = "fallback_default_plus_mock_cfg"
+        except Exception:
+            config_opts["load_error"] = repr(exc)
+
+    values = dict(defaults)
+    for key in defaults:
+        try:
+            if key in config_opts:
+                values[key] = config_opts[key]
+        except Exception:
+            pass
+    values["source"] = source
+    return values
+
+
+def _package_manager_key(name):
+    if name == "dnf":
+        return "dnf4"
+    return name
+
+
+def _packages_from_install_command(command):
+    if not command:
+        return []
+    tokens = shlex.split(command) if isinstance(command, str) else list(command)
+    if tokens and tokens[0] in ("install", "dnf-install"):
+        tokens = tokens[1:]
+    return [token for token in tokens if token and not token.startswith("-")]
+
+
+def _discover_bootstrap_toolchain(mock_cfg):
+    config = _load_mock_config_values(mock_cfg)
+    pm = _package_manager_key(str(config.get("package_manager") or "dnf"))
+    install_command = config.get(f"{pm}_install_command")
+    requested = _packages_from_install_command(install_command)
+    requested.extend(config.get("bootstrap_chroot_additional_packages") or [])
+    requested = sorted(set(requested))
+    enabled = bool(config.get("use_bootstrap")) and bool(requested)
+    return {
+        "status": "pending" if enabled else "disabled",
+        "source": config.get("source"),
+        "package_manager": pm,
+        "use_bootstrap": bool(config.get("use_bootstrap")),
+        "use_bootstrap_image": bool(config.get("use_bootstrap_image")),
+        "install_command": install_command,
+        "requested_packages": requested,
+    }
+
+
+def _infer_releasever(buildroot):
+    tag = buildroot.get("tag_name") or ""
+    match = re.search(r"an(\d+)", tag)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _dnf_download_bootstrap_toolchain(toolchain, buildroot, repo_dir, metadata_dir, external_repos):
+    requested = toolchain.get("requested_packages") or []
+    if not requested:
+        toolchain["status"] = "disabled"
+        return []
+
+    dnf = shutil.which("dnf") or shutil.which("dnf-3")
+    if not dnf:
+        toolchain["status"] = "unavailable"
+        toolchain["error"] = "dnf or dnf-3 is required to resolve mock bootstrap toolchain"
+        return []
+
+    installroot = Path(metadata_dir) / "bootstrap-installroot"
+    installroot.mkdir(parents=True, exist_ok=True)
+    download_dir = Path(metadata_dir) / "bootstrap-downloads"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        dnf,
+        "-y",
+        "--nogpgcheck",
+        "--disableplugin=releasever_adapter",
+        "--setopt=reposdir=/dev/null",
+        "--setopt=gpgcheck=0",
+        "--setopt=repo_gpgcheck=0",
+        "--setopt=install_weak_deps=0",
+        "--installroot",
+        str(installroot),
+        "--downloaddir",
+        str(download_dir),
+        "--downloadonly",
+        "--repofrompath",
+        "fallback-buildroot,file://%s" % os.path.abspath(str(repo_dir)),
+        "--enablerepo",
+        "fallback-buildroot",
+    ]
+    releasever = _infer_releasever(buildroot)
+    if releasever:
+        cmd.extend(["--releasever", releasever])
+
+    for index, repo in enumerate(external_repos or []):
+        if repo.get("status") != "ready":
+            continue
+        repo_id = "external-%d-%s" % (index, re.sub(r"[^A-Za-z0-9_.-]+", "_", repo["external_repo_name"]))
+        cmd.extend(["--repofrompath", "%s,%s" % (repo_id, repo["resolved_url"])])
+        cmd.extend(["--enablerepo", repo_id])
+
+    cmd.extend(["install"])
+    cmd.extend(requested)
+
+    before = set(Path(repo_dir).glob("*.rpm"))
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        toolchain["resolver_command"] = " ".join(shlex.quote(part) for part in cmd)
+        toolchain["resolver_output"] = proc.stdout[-8000:]
+    except Exception as exc:
+        toolchain["status"] = "incomplete"
+        toolchain["error"] = repr(exc)
+        if hasattr(exc, "stdout") and exc.stdout:
+            toolchain["resolver_output"] = exc.stdout[-8000:]
+        return []
+
+    for path in sorted(download_dir.glob("*.rpm")):
+        shutil.copy2(path, Path(repo_dir) / path.name)
+    after = set(Path(repo_dir).glob("*.rpm"))
+    new_paths = sorted(after - before)
+    artifacts = []
+    for path in new_paths:
+        artifact = summarize_file(path, label="bootstrap_toolchain_rpm")
+        artifact["source_type"] = "mock_bootstrap_toolchain"
+        artifacts.append(artifact)
+    toolchain["status"] = "ready"
+    toolchain["releasever"] = releasever
+    toolchain["downloaded"] = len(artifacts)
+    toolchain["rpms"] = artifacts
+    toolchain["historical_exactness"] = "not_proven"
+    toolchain["repo_visibility"] = "visible_to_bootstrap_and_final_buildroot"
+    return artifacts
+
+
+def rewrite_mock_config_for_local_repo(source_cfg, dest_cfg, repo_dir, releasever=None):
+    source_cfg = Path(source_cfg)
+    dest_cfg = Path(dest_cfg)
+    dest_cfg.parent.mkdir(parents=True, exist_ok=True)
+    text = source_cfg.read_text()
+    local_url = "file://%s" % os.path.abspath(str(repo_dir))
+    rewritten, count = re.subn(r"baseurl=[^\\']+", "baseurl=%s" % local_url, text)
+    if count == 0:
+        raise RuntimeError("mock.cfg does not contain a repo baseurl to rewrite")
+    if releasever and "config_opts['releasever']" not in rewritten and 'config_opts["releasever"]' not in rewritten:
+        rewritten += "\n# Local fallback bootstrap resolver hint.\n"
+        rewritten += "config_opts['releasever'] = '%s'\n" % releasever
+    dest_cfg.write_text(rewritten)
+    return dest_cfg
+
+
+def _public_artifact(summary):
+    if not summary:
+        return None
+    return dict(
+        (key, summary[key])
+        for key in (
+            "file",
+            "url",
+            "size",
+            "sha256",
+            "label",
+            "source_type",
+            "task_id",
+            "external_repo_name",
+            "repo_checksum",
+            "error",
+        )
+        if key in summary
+    )
+
+
+def _public_external_item(item):
+    if not item:
+        return None
+    result = {}
+    for key in ("nevra", "rpm_lookup", "source_repo", "url", "error"):
+        if key in item:
+            result[key] = item[key]
+    if "verification" in item:
+        verification = item["verification"]
+        result["verification"] = {
+            "checks": verification.get("checks"),
+            "matched": verification.get("matched"),
+            "rpm_header": verification.get("rpm_header"),
+        }
+    if "artifact" in item:
+        result["artifact"] = _public_artifact(item["artifact"])
+    return result
+
+
+def summarize_fallback_report(report, max_items=20):
+    recovery = report.get("dependency_recovery", {})
+    local_repo = report.get("local_repo") or {}
+    external = report.get("external_repo_recovery") or {}
+    bootstrap = report.get("bootstrap_toolchain") or {}
+    summary = {
+        "strategy": report.get("strategy"),
+        "status": report.get("status"),
+        "error": report.get("error"),
+        "source_task_id": report.get("source_task_id"),
+        "installed_pkgs_log": _public_artifact(report.get("installed_pkgs_log")),
+        "local_repo": {
+            "rpm_count": local_repo.get("rpm_count"),
+            "comps": _public_artifact(local_repo.get("comps")),
+        }
+        if local_repo
+        else None,
+        "mock_config": _public_artifact(report.get("mock_config")),
+        "dependency_recovery": {
+            "total": recovery.get("total"),
+            "resolved_by_getRPM": recovery.get("resolved_by_getRPM"),
+            "resolved_by_external_repo": recovery.get("resolved_by_external_repo"),
+            "unresolved": recovery.get("unresolved"),
+            "payloadhash_mismatch": recovery.get("payloadhash_mismatch"),
+            "task_output_available": recovery.get("task_output_available"),
+            "missing_task_output": recovery.get("missing_task_output"),
+            "downloaded": recovery.get("downloaded"),
+            "download_errors": recovery.get("download_errors"),
+        },
+        "external_repo_recovery": {
+            "status": external.get("status"),
+            "event_id": external.get("event_id"),
+            "repo_count": len(external.get("repos") or []),
+            "resolved": len(external.get("resolved") or []),
+            "unresolved": len(external.get("unresolved") or []),
+            "verification_failed": len(external.get("verification_failed") or []),
+            "download_errors": len(external.get("download_errors") or []),
+        }
+        if external
+        else None,
+        "bootstrap_toolchain": {
+            "status": bootstrap.get("status"),
+            "source": bootstrap.get("source"),
+            "package_manager": bootstrap.get("package_manager"),
+            "install_command": bootstrap.get("install_command"),
+            "requested_packages": bootstrap.get("requested_packages"),
+            "downloaded": bootstrap.get("downloaded"),
+            "releasever": bootstrap.get("releasever"),
+            "historical_exactness": bootstrap.get("historical_exactness"),
+            "repo_visibility": bootstrap.get("repo_visibility"),
+            "error": bootstrap.get("error"),
+        }
+        if bootstrap
+        else None,
+    }
+    for key in ("unresolved_items", "payloadhash_mismatch_items", "missing_task_output_items", "download_error_items"):
+        values = recovery.get(key) or []
+        if values:
+            summary["dependency_recovery"][key] = values[:max_items]
+            summary["dependency_recovery"][key + "_truncated"] = len(values) > max_items
+    if external:
+        for key in ("resolved", "unresolved", "verification_failed", "download_errors"):
+            values = external.get(key) or []
+            if values:
+                if key == "resolved":
+                    summary["external_repo_recovery"][key + "_items"] = [
+                        _public_external_item(item) for item in values[:max_items]
+                    ]
+                else:
+                    summary["external_repo_recovery"][key + "_items"] = values[:max_items]
+                summary["external_repo_recovery"][key + "_truncated"] = len(values) > max_items
+    return dict((key, value) for key, value in summary.items() if value is not None)
+
+
+def prepare_installed_pkgs_fallback(
+    client,
+    buildroot,
+    installed_pkgs_log,
+    base_mock_cfg,
+    fallback_mock_cfg,
+    repo_dir,
+    metadata_dir,
+    source_task_id,
+):
+    installed_pkgs_log = Path(installed_pkgs_log)
+    repo_dir = Path(repo_dir)
+    metadata_dir = Path(metadata_dir)
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = parse_installed_pkgs(installed_pkgs_log)
+    rpm_cache = {}
+    build_cache = {}
+    task_output_cache = {}
+    resolved = []
+    unresolved_by_getrpm = []
+    payload_mismatch = []
+    missing_task_output = []
+
+    for entry in entries:
+        rpm = rpm_cache.get(entry["rpm_lookup"])
+        if entry["rpm_lookup"] not in rpm_cache:
+            rpm = client.get_rpm_optional(entry["rpm_lookup"])
+            rpm_cache[entry["rpm_lookup"]] = rpm
+        if not rpm:
+            unresolved_by_getrpm.append(entry)
+            continue
+        if rpm.get("payloadhash") and rpm.get("payloadhash") != entry.get("payloadhash"):
+            payload_mismatch.append(
+                {
+                    "nevra": entry["nevra"],
+                    "rpm_lookup": entry["rpm_lookup"],
+                    "installed_payloadhash": entry.get("payloadhash"),
+                    "koji_payloadhash": rpm.get("payloadhash"),
+                }
+            )
+            continue
+
+        build_id = rpm["build_id"]
+        build = build_cache.get(build_id)
+        if build_id not in build_cache:
+            build = client.get_build(build_id)
+            build_cache[build_id] = build
+
+        filename = rpm_filename(rpm)
+        output_task_id = _find_task_output(client, build["task_id"], filename, task_output_cache)
+        if output_task_id is None:
+            missing_task_output.append(
+                {
+                    "nevra": entry["nevra"],
+                    "filename": filename,
+                    "build_id": build_id,
+                    "build_task_id": build.get("task_id"),
+                }
+            )
+            continue
+
+        resolved.append(
+            {
+                "entry": entry,
+                "name": rpm["name"],
+                "rpm": rpm,
+                "source_type": "koji_task_output",
+                "build_id": build_id,
+                "build_task_id": build.get("task_id"),
+                "output_task_id": output_task_id,
+                "filename": filename,
+            }
+        )
+
+    external_resolved = []
+    external_report = None
+    if unresolved_by_getrpm and buildroot:
+        external_resolved, external_report = _recover_external_rpms(
+            client,
+            buildroot,
+            unresolved_by_getrpm,
+            repo_dir,
+            metadata_dir,
+        )
+        for item in external_resolved:
+            parsed = _parse_nevra(item["entry"]["rpm_lookup"])
+            item["name"] = parsed["name"]
+        resolved.extend(external_resolved)
+
+    unresolved = []
+    if external_report:
+        unresolved = external_report.get("unresolved") or []
+    else:
+        unresolved = unresolved_by_getrpm
+
+    recovery = {
+        "total": len(entries),
+        "resolved_by_getRPM": len(entries) - len(unresolved_by_getrpm),
+        "resolved_by_external_repo": len(external_resolved),
+        "unresolved": len(unresolved),
+        "payloadhash_mismatch": len(payload_mismatch),
+        "task_output_available": len([item for item in resolved if item.get("source_type") == "koji_task_output"]),
+        "missing_task_output": len(missing_task_output),
+        "downloaded": 0,
+        "download_errors": len((external_report or {}).get("download_errors") or []),
+        "unresolved_items": unresolved,
+        "unresolved_by_getRPM_items": unresolved_by_getrpm,
+        "payloadhash_mismatch_items": payload_mismatch,
+        "missing_task_output_items": missing_task_output,
+        "download_error_items": list((external_report or {}).get("download_errors") or []),
+    }
+    report = {
+        "strategy": "installed_pkgs_log",
+        "status": "incomplete",
+        "source_task_id": source_task_id,
+        "installed_pkgs_log": summarize_file(installed_pkgs_log, label="koji_task_log"),
+        "dependency_recovery": recovery,
+    }
+    if external_report:
+        report["external_repo_recovery"] = external_report
+
+    external_failed = external_report and external_report.get("status") != "ready"
+    if unresolved or payload_mismatch or missing_task_output or external_failed:
+        return report
+
+    downloaded = []
+    seen = set()
+    for item in resolved:
+        filename = item["filename"]
+        if filename in seen:
+            continue
+        seen.add(filename)
+        try:
+            if item.get("source_type") == "external_repo":
+                artifact = item["artifact"]
+            else:
+                artifact = _download_dependency(client, item["output_task_id"], filename, repo_dir)
+                artifact["source_type"] = "koji_task_output"
+                artifact["task_id"] = item["output_task_id"]
+            downloaded.append(artifact)
+        except Exception as exc:
+            recovery["download_error_items"].append(
+                {
+                    "filename": filename,
+                    "task_id": item["output_task_id"],
+                    "error": repr(exc),
+                }
+            )
+
+    recovery["downloaded"] = len(downloaded)
+    recovery["download_errors"] = len(recovery["download_error_items"])
+    if recovery["download_errors"]:
+        return report
+
+    try:
+        comps_xml = metadata_dir / "fallback-comps.xml"
+        _write_comps(resolved, comps_xml)
+        _run_createrepo(repo_dir, comps_xml)
+
+        bootstrap = _discover_bootstrap_toolchain(base_mock_cfg)
+        if bootstrap.get("status") != "disabled":
+            if not external_report and buildroot:
+                external_report = {
+                    "status": "ready",
+                    "event_id": _repo_event(buildroot),
+                    "repos": _external_repo_metadata(client, buildroot, metadata_dir),
+                    "resolved": [],
+                    "unresolved": [],
+                    "verification_failed": [],
+                    "download_errors": [],
+                }
+                if any(repo.get("status") != "ready" for repo in external_report["repos"]):
+                    external_report["status"] = "partial"
+                report["external_repo_recovery"] = external_report
+            bootstrap_artifacts = _dnf_download_bootstrap_toolchain(
+                bootstrap,
+                buildroot or {},
+                repo_dir,
+                metadata_dir,
+                (external_report or {}).get("repos") or [],
+            )
+            downloaded.extend(bootstrap_artifacts)
+            if bootstrap.get("status") not in ("ready", "disabled"):
+                report["bootstrap_toolchain"] = bootstrap
+                return report
+            _run_createrepo(repo_dir, comps_xml)
+        report["bootstrap_toolchain"] = bootstrap
+
+        rewrite_mock_config_for_local_repo(
+            base_mock_cfg,
+            fallback_mock_cfg,
+            repo_dir,
+            releasever=_infer_releasever(buildroot or {}),
+        )
+    except Exception as exc:
+        report["status"] = "error"
+        report["error"] = repr(exc)
+        return report
+
+    report["status"] = "ready"
+    report["local_repo"] = {
+        "path": str(repo_dir),
+        "rpm_count": len(downloaded),
+        "comps": summarize_file(comps_xml),
+    }
+    report["mock_config"] = summarize_file(fallback_mock_cfg)
+    report["dependency_rpms"] = downloaded
+    return report

--- a/tests/test_container_executor.py
+++ b/tests/test_container_executor.py
@@ -1,0 +1,64 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from guanfu.koji_rebuild.container_executor import (
+    CONTAINER_WORKDIR,
+    build_container_command,
+    detect_target_os,
+)
+
+
+class ContainerExecutorTests(unittest.TestCase):
+    def test_detect_target_os_from_buildroot_tag(self):
+        self.assertEqual(
+            detect_target_os(buildroot={"tag_name": "dist-an23.0-build"}),
+            "an23",
+        )
+
+    def test_detect_target_os_from_rpm_release(self):
+        self.assertEqual(
+            detect_target_os(rpm_info={"release": "3.an23"}),
+            "an23",
+        )
+
+    def test_unknown_target_is_not_supported(self):
+        self.assertIsNone(
+            detect_target_os(
+                rpm_info={"release": "1.an8"},
+                buildroot={"tag_name": "dist-an8-build"},
+            )
+        )
+
+    def test_container_command_reexecs_with_local_executor(self):
+        args = SimpleNamespace(
+            rpm_name="acl-2.3.1-3.an23.x86_64.rpm",
+            koji_server="https://build.openanolis.cn/kojihub",
+            koji_topurl="https://build.openanolis.cn/kojifiles",
+            binary_rpm_base_url="https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/",
+            source_rpm_base_url="https://mirrors.openanolis.cn/anolis/23/os/source/Packages/",
+            runs=1,
+            isolation="simple",
+            repo_fallback="installed-pkgs",
+            container_privileged=True,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            expected_mount = f"{Path(tmp).resolve()}:{CONTAINER_WORKDIR}"
+            command = build_container_command(args, "docker", "example/an23:latest", Path(tmp))
+
+        self.assertEqual(command[:4], ["docker", "run", "--rm", "--privileged"])
+        self.assertIn(expected_mount, command)
+        self.assertIn("GUANFU_IN_CONTAINER=1", command)
+        self.assertIn("GUANFU_TARGET_OS=an23", command)
+        self.assertIn("example/an23:latest", command)
+
+        inner = command[command.index("guanfu") :]
+        self.assertEqual(inner[:3], ["guanfu", "rebuild", "koji-rpm"])
+        self.assertIn("--executor", inner)
+        self.assertEqual(inner[inner.index("--executor") + 1], "local")
+        self.assertEqual(inner[inner.index("--workdir") + 1], CONTAINER_WORKDIR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,60 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from guanfu.koji_rebuild.mock_runner import _diagnose_mock_failure, run_rebuild
+
+
+class DiagnosticsTests(unittest.TestCase):
+    def test_detects_buildroot_runtime_crash_from_scriptlet_signal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resultdir = Path(tmp)
+            (resultdir / "root.log").write_text(
+                "warning: %post(p11-kit-trust) scriptlet failed, signal 11\n"
+                "Error: Transaction failed\n"
+            )
+
+            diagnosis = _diagnose_mock_failure(resultdir)
+
+        self.assertIsNotNone(diagnosis)
+        self.assertEqual(diagnosis["category"], "buildroot_runtime_incompatible")
+        self.assertIn("VM", diagnosis["suggested_action"])
+        self.assertEqual(diagnosis["evidence"][0]["log"], "root.log")
+
+    def test_ignores_regular_rpmbuild_test_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resultdir = Path(tmp)
+            (resultdir / "build.log").write_text(
+                "make: *** [Makefile:1298: test] Error 1\n"
+                "Bad exit status from /var/tmp/rpm-tmp (%check)\n"
+            )
+
+            diagnosis = _diagnose_mock_failure(resultdir)
+
+        self.assertIsNone(diagnosis)
+
+    def test_run_rebuild_attaches_failure_diagnosis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            resultdir = tmp / "result"
+
+            def fake_run(_cmd):
+                (resultdir / "root.log").write_text(
+                    "error: %prein(rpm) scriptlet failed, signal 11\n"
+                )
+                return SimpleNamespace(returncode=30)
+
+            with patch("subprocess.run", side_effect=fake_run):
+                result = run_rebuild(tmp / "mock.cfg", tmp / "pkg.src.rpm", resultdir)
+
+        self.assertEqual(result["exit_code"], 30)
+        self.assertEqual(
+            result["failure_diagnosis"]["category"],
+            "buildroot_runtime_incompatible",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_config.py
+++ b/tests/test_mock_config.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from guanfu.koji_rebuild.mock_config import enforce_nonroot_mock_build_user
+
+
+class MockConfigTests(unittest.TestCase):
+    def test_enforce_nonroot_mock_build_user_replaces_root_uid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mock.cfg"
+            path.write_text(
+                "config_opts['chrootuid'] = 0\n"
+                "config_opts['chrootgid'] = 135\n"
+                "config_opts['root'] = 'dist-an23-build'\n"
+            )
+
+            enforce_nonroot_mock_build_user(path)
+
+            text = path.read_text()
+        self.assertIn("config_opts['chrootuid'] = 1000", text)
+        self.assertIn("config_opts['chrootgid'] = 135", text)
+        self.assertNotIn("config_opts['chrootuid'] = 0", text)
+
+    def test_enforce_nonroot_mock_build_user_appends_missing_options(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mock.cfg"
+            path.write_text("config_opts['root'] = 'dist-an23-build'\n")
+
+            enforce_nonroot_mock_build_user(path, uid=2000)
+
+            text = path.read_text()
+        self.assertIn("# GuanFu container mock user override.", text)
+        self.assertIn("config_opts['chrootuid'] = 2000", text)
+        self.assertNotIn("chrootgid", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_runner.py
+++ b/tests/test_mock_runner.py
@@ -1,0 +1,29 @@
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from guanfu.koji_rebuild.mock_runner import run_rebuild
+
+
+class MockRunnerTests(unittest.TestCase):
+    def test_container_resultdir_is_writable_by_nonroot_mockbuild_user(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            resultdir = tmp / "result"
+            with patch.dict(
+                os.environ,
+                {"GUANFU_EXECUTOR_MODE": "container", "GUANFU_IN_CONTAINER": "1"},
+            ), patch("subprocess.run", return_value=SimpleNamespace(returncode=0)):
+                run_rebuild(tmp / "mock.cfg", tmp / "pkg.src.rpm", resultdir)
+
+            mode = stat.S_IMODE(resultdir.stat().st_mode)
+
+        self.assertEqual(mode, 0o777)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repo_fallback.py
+++ b/tests/test_repo_fallback.py
@@ -1,0 +1,156 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from guanfu.koji_rebuild.repo_fallback import (
+    _packages_from_install_command,
+    _replace_repo_arch,
+    parse_installed_pkgs,
+    rewrite_mock_config_for_local_repo,
+    summarize_fallback_report,
+)
+
+
+class RepoFallbackTests(unittest.TestCase):
+    def test_parse_installed_pkgs_strips_epoch_for_lookup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "installed_pkgs.log"
+            path.write_text(
+                "fonts-filesystem-1:4.0.2-4.an23.noarch 1681297983 0 "
+                "caaa42e89bc6a7f73211a3bcc9c85783 installed\n"
+            )
+
+            entries = parse_installed_pkgs(path)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["nevra"], "fonts-filesystem-1:4.0.2-4.an23.noarch")
+        self.assertEqual(entries[0]["rpm_lookup"], "fonts-filesystem-4.0.2-4.an23.noarch")
+        self.assertEqual(entries[0]["payloadhash"], "caaa42e89bc6a7f73211a3bcc9c85783")
+
+    def test_rewrite_mock_config_replaces_repo_baseurl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            source = tmp / "mock.cfg"
+            dest = tmp / "mock-fallback.cfg"
+            repo = tmp / "repo"
+            repo.mkdir()
+            source.write_text(
+                "config_opts['yum.conf'] = '[main]\\n"
+                "[build]\\n"
+                "name=build\\n"
+                "baseurl=https://build.openanolis.cn/kojifiles/repos/dist/1/x86_64\\n'\n"
+            )
+
+            rewrite_mock_config_for_local_repo(source, dest, repo)
+
+            rewritten = dest.read_text()
+        self.assertIn("baseurl=file://", rewritten)
+        self.assertIn(str(repo), rewritten)
+        self.assertNotIn("https://build.openanolis.cn/kojifiles/repos", rewritten)
+
+    def test_rewrite_mock_config_can_add_releasever(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            source = tmp / "mock.cfg"
+            dest = tmp / "mock-fallback.cfg"
+            repo = tmp / "repo"
+            repo.mkdir()
+            source.write_text(
+                "config_opts['yum.conf'] = '[main]\\n"
+                "[build]\\n"
+                "name=build\\n"
+                "baseurl=https://build.openanolis.cn/kojifiles/repos/dist/1/x86_64\\n'\n"
+            )
+
+            rewrite_mock_config_for_local_repo(source, dest, repo, releasever="23")
+
+            self.assertIn("config_opts['releasever'] = '23'", dest.read_text())
+
+    def test_external_repo_url_replaces_arch_tokens(self):
+        self.assertEqual(
+            _replace_repo_arch("https://example.invalid/$arch/os/${arch}/$basearch/", "x86_64"),
+            "https://example.invalid/x86_64/os/x86_64/x86_64/",
+        )
+
+    def test_packages_from_install_command_skips_command_and_options(self):
+        self.assertEqual(
+            _packages_from_install_command("install --setopt=a=b python3-dnf python3-dnf-plugins-core"),
+            ["python3-dnf", "python3-dnf-plugins-core"],
+        )
+
+    def test_summarize_fallback_report_omits_local_paths(self):
+        summary = summarize_fallback_report(
+            {
+                "strategy": "installed_pkgs_log",
+                "status": "incomplete",
+                "source_task_id": 123,
+                "installed_pkgs_log": {
+                    "file": "installed_pkgs.log",
+                    "path": "/tmp/run/inputs/installed_pkgs.log",
+                    "size": 10,
+                    "sha256": "abc",
+                },
+                "dependency_recovery": {
+                    "total": 1,
+                    "resolved_by_getRPM": 0,
+                    "unresolved": 1,
+                    "payloadhash_mismatch": 0,
+                    "task_output_available": 0,
+                    "missing_task_output": 0,
+                    "downloaded": 0,
+                    "download_errors": 0,
+                },
+            }
+        )
+
+        self.assertNotIn("path", summary["installed_pkgs_log"])
+
+    def test_summarize_fallback_report_includes_external_and_bootstrap(self):
+        summary = summarize_fallback_report(
+            {
+                "strategy": "installed_pkgs_log",
+                "status": "ready",
+                "dependency_recovery": {
+                    "total": 2,
+                    "resolved_by_getRPM": 1,
+                    "resolved_by_external_repo": 1,
+                    "unresolved": 0,
+                    "payloadhash_mismatch": 0,
+                    "task_output_available": 1,
+                    "missing_task_output": 0,
+                    "downloaded": 2,
+                    "download_errors": 0,
+                },
+                "external_repo_recovery": {
+                    "status": "ready",
+                    "event_id": 123,
+                    "repos": [{"external_repo_name": "fc36"}],
+                    "resolved": [
+                        {
+                            "nevra": "kernel-headers-5.17.0-300.fc36.x86_64",
+                            "artifact": {
+                                "file": "kernel-headers.rpm",
+                                "path": "/tmp/private/kernel-headers.rpm",
+                                "sha256": "abc",
+                            },
+                        }
+                    ],
+                },
+                "bootstrap_toolchain": {
+                    "status": "ready",
+                    "package_manager": "dnf4",
+                    "requested_packages": ["python3-dnf"],
+                    "downloaded": 8,
+                    "historical_exactness": "not_proven",
+                },
+            }
+        )
+
+        self.assertEqual(summary["dependency_recovery"]["resolved_by_external_repo"], 1)
+        self.assertEqual(summary["external_repo_recovery"]["resolved"], 1)
+        self.assertNotIn("path", summary["external_repo_recovery"]["resolved_items"][0]["artifact"])
+        self.assertEqual(summary["bootstrap_toolchain"]["downloaded"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the default container executor path for an23 Koji RPM rebuilds
- recover missing historical repos with installed_pkgs.log, Koji task outputs, external repo metadata, and mock bootstrap dependencies
- add lightweight mock failure diagnosis that suggests VM execution for old buildroot runtime crashes
- document container, fallback, and VM guidance for OpenAnolis Koji rebuilds

## Tests
- env PYTHONPATH=src python3 -m unittest discover -s tests