### PR TITLE
Add generic Koji profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # GuanFu
 
-A GitHub Action for **reproducible container-based builds**. GuanFu reads a declarative `buildspec.yaml`, launches a container, and executes build phases inside it — producing deterministic, auditable artifacts.
+GuanFu is a reproducible rebuild toolkit. It supports the original declarative
+`buildspec.yaml` container workflow, and also provides a local CLI path for
+rebuilding published OpenAnolis Koji RPMs inside a controlled VM executor.
 
 ## Features
 
 - **Declarative build specs** — Define container image, inputs, environment, build phases, and outputs in a single YAML file.
-- **Container isolation** — All builds run inside Docker containers for consistency across environments.
+- **Buildspec container isolation** — Declarative buildspec rebuilds run inside Docker containers for consistency across environments.
 - **Reproducible builds** — Pre-configured `SOURCE_DATE_EPOCH`, RPM macros, and Rust compiler flags for bit-for-bit reproducibility.
 - **Input management** — Download remote artifacts or mount local files into the build container, with optional SHA-256 verification.
 - **Multi-OS support** — Built-in runners for Anolis OS and Alibaba Cloud Linux, extensible to other distributions.
 - **Local CLI** — Use `guanfu` to run the existing buildspec rebuild flow or rebuild published OpenAnolis Koji RPMs locally.
+- **Koji RPM VM rebuild** — Resolve published RPMs back to Koji build metadata, SRPMs, mock configs, and logs; rebuild them in an an23 VM and compare against release RPMs.
 - **Release workflow** — Reusable GitHub Actions workflow with SLSA provenance generation and optional Rekor transparency log upload.
 
 ## Quick Start
@@ -96,7 +99,9 @@ guanfu rebuild koji-rpm \
   --rpm-name zlib-1.2.13-3.an23.x86_64.rpm
 ```
 
-Koji RPM rebuild requires a Linux host with `koji`, `createrepo_c`, and QEMU.
+Koji RPM rebuild currently supports an23 RPMs and requires a Linux host with
+`koji` plus QEMU/libguestfs tooling. `createrepo_c` is required when GuanFu must
+reconstruct a temporary repo from `installed_pkgs.log`.
 The default Koji executor is `--executor vm`; it uses KVM when `/dev/kvm` is
 available and otherwise falls back to slow degraded QEMU TCG. Use
 `--vm-require-kvm` for strict trusted runs. The default an23 VM image is:
@@ -106,8 +111,9 @@ installing system packages automatically. The host needs `qemu-img` and
 `virt-customize` to prepare the VM overlay. GuanFu uses QEMU 9p sharing when
 available, and falls back to `virt-copy-in` / `virt-copy-out` when the host QEMU
 lacks 9p support. By default the qcow2 overlay is prepared with `mock,rpm-build`
-before boot. Use `--executor local` only for host mock diagnostics or
-compatibility.
+before boot. `--executor local` remains available for compatibility and host
+mock diagnostics, but it shares the host kernel/CPU boundary and is not the
+default trusted route.
 
 ## Action Inputs
 
@@ -154,18 +160,25 @@ See [docs/workflow_usage_guide.md](docs/workflow_usage_guide.md) for details.
 ├── .github/workflows/
 │   └── release.yml             # Reusable release + SLSA provenance workflow
 └── docs/
-    ├── buildspec.md            # Buildspec YAML specification
-    ├── local_rebuild_guide.md  # Local build guide
-    └── workflow_usage_guide.md # CI workflow usage guide
+    ├── buildspec.md                         # Buildspec YAML specification
+    ├── local_rebuild_guide.md               # Local build and Koji RPM rebuild guide
+    ├── koji_bootstrap_toolchain_fallback.md # Future strict bootstrap fallback design
+    └── workflow_usage_guide.md              # CI workflow usage guide
 ```
 
 ## Supported Operating Systems
+
+For the buildspec container workflow:
 
 | OS                  | Status    |
 |---------------------|-----------|
 | Anolis OS           | Supported |
 | Alibaba Cloud Linux | Supported |
 | Others              | Extensible via `OsRunnerBase` |
+
+For Koji RPM VM rebuild, this PR currently supports OpenAnolis an23 RPMs. Other
+targets such as an8, alinux3, and alinux4 are intentionally left to future
+policy support.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,23 @@ guanfu rebuild koji-rpm \
   --rpm-name zlib-1.2.13-3.an23.x86_64.rpm
 ```
 
+Rebuild from a standard Koji instance by selecting the generic profile:
+
+```bash
+guanfu rebuild koji-rpm \
+  --koji-profile generic-koji \
+  --koji-server http://koji-internal.jinzihao.me/kojihub \
+  --koji-topurl http://koji-internal.jinzihao.me/kojifiles \
+  --rpm-name anothertest-1.0.0-21.al8.x86_64.rpm
+```
+
 Koji RPM rebuild currently supports an23 RPMs and requires a Linux host with
-`koji` plus QEMU/libguestfs tooling. `createrepo_c` is required when GuanFu must
-reconstruct a temporary repo from `installed_pkgs.log`.
-The default Koji executor is `--executor vm`; it uses KVM when `/dev/kvm` is
+QEMU/libguestfs tooling for the VM executor. Generic Koji profiles default to
+the local executor and use `mock_config.log` from task output when available,
+falling back to `koji mock-config` if needed. `createrepo_c` is required when
+GuanFu must reconstruct a temporary repo from `installed_pkgs.log`.
+The default executor is profile-driven: OpenAnolis an23 uses `vm`, while
+generic Koji uses `local`. The an23 VM executor uses KVM when `/dev/kvm` is
 available and otherwise falls back to slow degraded QEMU TCG. Use
 `--vm-require-kvm` for strict trusted runs. The default an23 VM image is:
 `https://mirrors.openanolis.cn/anolis/23/isos/GA/x86_64/AnolisOS-23.4-x86_64.qcow2`.

--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -1,15 +1,17 @@
 # 本地重复构建指南
 
-本指南将介绍如何使用 GuanFu 在本地环境中基于指定的 `buildspec.yaml` 文件实现重复构建。
+本指南介绍如何使用 GuanFu 在本地运行两类 rebuild：基于 `buildspec.yaml` 的既有容器构建流程，以及基于 OpenAnolis Koji 发布 RPM 的本地 VM rebuild 流程。
 
 ## 前提条件
 
-在开始本地重复构建之前，请确保您已满足以下条件：
+运行 buildspec 容器 rebuild 前，请确保您已满足以下条件：
 
 1. 已安装 Docker
 2. 已安装 Python 3.6+
 3. 已安装 Git
 4. 已安装 YAML 解析器（PyYAML 包）
+
+运行 Koji RPM VM rebuild 还需要 Linux host，以及 `koji`、QEMU/libguestfs 工具链；当历史 repo 不存在并启用 installed-pkgs fallback 时，还需要 `createrepo_c`。macOS 不能原生运行 mock，建议使用 Linux VM 或远程 Linux 主机。
 
 ## 使用方法
 
@@ -74,8 +76,9 @@ guanfu rebuild koji-rpm \
 4. 从发布 source repo 获取 SRPM，并下载 Koji task SRPM/logs 做同源校验
 5. 使用 Koji `buildroot_id` 生成 `mock.cfg`
 6. 若历史 repo 不存在，使用 `installed_pkgs.log` 恢复临时本地 repo
-7. 通过 QEMU/KVM 启动 VM，将本次运行目录挂载到 VM 内，并在 VM 中执行 `mock --rebuild`
-8. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
+7. 通过 QEMU 启动 VM；KVM 可用时使用 KVM，否则降级到 TCG，并通过 9p 挂载或 `virt-copy-in` / `virt-copy-out` 交换本次运行目录
+8. 在 VM 中执行 `mock --rebuild`
+9. 对比发布 RPM 和本地 rebuild RPM，并输出 `report.json`
 
 如果需要保留当前 host 上直接运行 mock 的行为，可以显式使用 local executor：
 
@@ -136,7 +139,7 @@ invalid opcode
 Transaction failed（通常伴随 scriptlet signal 4/11）
 ```
 
-这类失败通常不表示 SRPM、`mock.cfg` 或依赖恢复一定有问题，而可能是本地执行环境和 Koji builder 的 CPU/kernel 边界不一致。默认 VM executor 会通过 KVM/QEMU 固定更接近 Koji builder 的 CPU model。当前 an23 实验中，`Cascadelake-Server-v1` VM 已验证可以让 `acl`、`bzip2`、`which` 这类 old an23 buildroot 正常完成 rebuild。
+这类失败通常不表示 SRPM、`mock.cfg` 或依赖恢复一定有问题，而可能是本地执行环境和 Koji builder 的 CPU/kernel 边界不一致。默认 VM executor 会通过 KVM/QEMU 固定更接近 Koji builder 的 CPU model。当前 an23 实验中，`Cascadelake-Server-v1` VM 已验证可以让 `acl`、`bzip2` 这类历史 repo 已失效的包通过 installed-pkgs fallback 正常完成 rebuild；`sqlite-libs` 在无 KVM 的 TCG 测试机上进入 `%check` 后触发 7200 秒 timeout，因此这类重包需要在有 KVM 的机器上复测。
 
 GuanFu 会在 mock 失败后读取 `root.log`、`build.log` 和 `state.log`。如果检测到上述旧 buildroot 运行时崩溃特征，`report.json` 的 `rebuild.failure_diagnosis` 会给出 `buildroot_runtime_incompatible` 诊断、证据行和 VM 重试建议。
 
@@ -203,5 +206,5 @@ binary RPM base URL: https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packag
 host 侧需要 QEMU、`qemu-img`、`virt-customize`，如果 QEMU 不支持 9p 或显式使用 `image-copy`，
 还需要 `virt-copy-in` 和 `virt-copy-out`。an23 默认 qcow2 镜像来自 OpenAnolis GA mirror，会自动下载
 并缓存；VM overlay 内的 `mock,rpm-build` 会自动准备。host 侧还需要 `guanfu`、`koji` 和
-`createrepo_c` 用于准备输入或 installed-pkgs fallback。local executor 需要 Linux 环境，并在 host 上
+`createrepo_c` 用于 installed-pkgs fallback。local executor 需要 Linux 环境，并在 host 上
 安装这些工具；macOS 不能原生运行 local mock，需要使用 Linux 虚拟机或远程 Linux 主机。

--- a/docs/local_rebuild_guide.md
+++ b/docs/local_rebuild_guide.md
@@ -68,6 +68,25 @@ guanfu rebuild koji-rpm \
 
 `koji-rpm` 默认走 VM 执行器。当前 VM 执行器只支持 an23 RPM；如果 Koji buildroot tag 或 RPM release 不能识别为 an23，GuanFu 会返回 `unsupported`，后续 an8、alinux3、alinux4 等发行版会由未来的 policy 模块接入。
 
+当前 `koji-rpm` 通过 profile 决定 artifact URL、mock config 来源和 executor。默认
+`--koji-profile auto` 会优先匹配 OpenAnolis an23，否则落到 `generic-koji`。`generic-koji`
+适用于标准 Koji 实例：RPM/SRPM 默认从 `--koji-topurl` 的 `packages/` 目录派生，
+mock 配置优先使用 buildArch task output 里的 `mock_config.log`，executor 默认使用
+`local`。
+
+例如验证一个普通 Koji 实例：
+
+```bash
+guanfu rebuild koji-rpm \
+  --koji-profile generic-koji \
+  --koji-server http://koji-internal.jinzihao.me/kojihub \
+  --koji-topurl http://koji-internal.jinzihao.me/kojifiles \
+  --rpm-name anothertest-1.0.0-21.al8.x86_64.rpm
+```
+
+如果 Koji 使用内部 CA，可以通过 `--koji-ca-cert PATH` 指定 CA；仅用于诊断时也可以使用
+`--koji-insecure-ssl` 跳过证书校验。
+
 默认流程会：
 
 1. 根据 RPM 名称查询 OpenAnolis Koji，定位 buildroot 和构建任务

--- a/src/guanfu/cli.py
+++ b/src/guanfu/cli.py
@@ -31,9 +31,9 @@ def build_parser():
         "koji-rpm",
         help="Rebuild an RPM produced by a Koji instance",
         description=(
-            "Rebuild an RPM produced by a Koji instance. The default executor runs "
-            "mock inside a Linux VM with a controlled CPU model, kernel, and tool "
-            "surface close to the Koji builder. KVM is trusted; TCG fallback is degraded."
+            "Rebuild an RPM produced by a Koji instance. GuanFu selects a Koji profile "
+            "by default: OpenAnolis an23 keeps the VM executor, while generic Koji "
+            "instances use the local executor unless explicitly configured otherwise."
         ),
         epilog=(
             "VM guidance: --executor vm currently supports an23. By default GuanFu "
@@ -62,13 +62,35 @@ def build_parser():
         help="Koji topurl for repos and mock-config",
     )
     koji.add_argument(
+        "--koji-profile",
+        default="auto",
+        help="Koji profile used to select artifact URLs, mock config providers, and executor policy.",
+    )
+    koji.add_argument(
+        "--koji-profile-file",
+        action="append",
+        default=[],
+        help="YAML file containing declarative Koji profile definitions. Can be passed more than once.",
+    )
+    koji.add_argument(
+        "--koji-ca-cert",
+        default=os.environ.get("GUANFU_KOJI_CA_CERT"),
+        help="Custom CA bundle used for Koji XML-RPC and artifact downloads.",
+    )
+    koji.add_argument(
+        "--koji-insecure-ssl",
+        action="store_true",
+        default=os.environ.get("GUANFU_KOJI_INSECURE_SSL", "").lower() in ("1", "true", "yes", "on"),
+        help="Disable TLS certificate verification for Koji XML-RPC and artifact downloads.",
+    )
+    koji.add_argument(
         "--binary-rpm-base-url",
-        default="https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/",
+        default=None,
         help="Base URL for published binary RPMs",
     )
     koji.add_argument(
         "--source-rpm-base-url",
-        default="https://mirrors.openanolis.cn/anolis/23/os/source/Packages/",
+        default=None,
         help="Base URL for published source RPMs",
     )
     koji.add_argument(
@@ -78,11 +100,11 @@ def build_parser():
     )
     koji.add_argument(
         "--executor",
-        choices=("vm", "local"),
-        default="vm",
+        choices=("auto", "vm", "local"),
+        default="auto",
         help=(
-            "Rebuild executor. vm is the default path; local keeps the host mock flow "
-            "for compatibility and diagnostics."
+            "Rebuild executor. auto follows the selected Koji profile; local keeps the "
+            "host mock flow for compatibility and diagnostics."
         ),
     )
     koji.add_argument(

--- a/src/guanfu/koji_rebuild/client.py
+++ b/src/guanfu/koji_rebuild/client.py
@@ -2,9 +2,12 @@ import xmlrpc.client
 
 
 class KojiClient:
-    def __init__(self, server_url):
+    def __init__(self, server_url, ssl_context=None):
         self.server_url = server_url
-        self.session = xmlrpc.client.ServerProxy(server_url, allow_none=True)
+        kwargs = {"allow_none": True}
+        if ssl_context is not None and server_url.startswith("https://"):
+            kwargs["context"] = ssl_context
+        self.session = xmlrpc.client.ServerProxy(server_url, **kwargs)
 
     def get_rpm(self, rpm_info):
         return self.session.getRPM(rpm_info, True, False)

--- a/src/guanfu/koji_rebuild/command.py
+++ b/src/guanfu/koji_rebuild/command.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 import sys
 import time
 from datetime import datetime
@@ -15,8 +16,8 @@ from guanfu.koji_rebuild.vm_executor import (
     vm_executor_summary,
 )
 from guanfu.koji_rebuild.downloader import (
+    build_tls_config,
     download_task_output,
-    join_url,
     summarize_file,
     try_download_url,
 )
@@ -27,8 +28,15 @@ from guanfu.koji_rebuild.repo_fallback import (
     prepare_installed_pkgs_fallback,
     summarize_fallback_report,
 )
+from guanfu.koji_rebuild.profiles import select_koji_profile
 from guanfu.koji_rebuild.resolver import resolve_koji_build
 from guanfu.koji_rebuild.rpm_name import parse_rpm_filename, rpm_filename
+
+
+class MockConfigUnavailable(RuntimeError):
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__("mock config is unavailable: %s" % "; ".join(errors))
 
 
 def _safe_name(name):
@@ -52,7 +60,15 @@ def _run_dir(workdir, rpm_name):
 
 def _download_koji_logs(client, task_id, outputs, inputs_dir):
     downloads = []
-    for log_name in ("build.log", "root.log", "installed_pkgs.log", "mock_output.log", "hw_info.log", "state.log"):
+    for log_name in (
+        "build.log",
+        "root.log",
+        "installed_pkgs.log",
+        "mock_output.log",
+        "mock_config.log",
+        "hw_info.log",
+        "state.log",
+    ):
         if log_name in outputs:
             path = download_task_output(client, task_id, log_name, inputs_dir / log_name)
             downloads.append(summarize_file(path, label="koji_task_log"))
@@ -64,11 +80,48 @@ def _download_task_srpm(client, task_id, srpm_name, inputs_dir):
     return path, summarize_file(path, label="koji_task_srpm")
 
 
-def _download_published(url, dest, label):
-    path, error = try_download_url(url, dest)
+def _download_published(url, dest, label, ssl_context=None):
+    path, error = try_download_url(url, dest, ssl_context=ssl_context)
     if error:
         return None, {"label": label, "url": url, "error": error}
     return path, summarize_file(path, label=label, url=url)
+
+
+def _prepare_mock_config(profile, client, args, resolution, inputs_dir, mock_cfg):
+    errors = []
+    for provider in profile.mock_config_providers:
+        if provider == "task-output-mock-config":
+            source = inputs_dir / "mock_config.log"
+            if not source.exists() and "mock_config.log" in (resolution.outputs or {}):
+                try:
+                    source = download_task_output(
+                        client,
+                        resolution.buildarch_task["id"],
+                        "mock_config.log",
+                        source,
+                    )
+                except Exception as exc:
+                    errors.append("%s: %r" % (provider, exc))
+                    continue
+            if source.exists():
+                shutil.copyfile(str(source), str(mock_cfg))
+                return mock_cfg, {"provider": provider, "source_file": source.name}
+            errors.append("%s: mock_config.log not found in task output" % provider)
+            continue
+        if provider == "koji-cli":
+            try:
+                generate_mock_config(
+                    args.koji_server,
+                    args.koji_topurl,
+                    resolution.buildroot["id"],
+                    mock_cfg,
+                )
+                return mock_cfg, {"provider": provider}
+            except Exception as exc:
+                errors.append("%s: %r" % (provider, exc))
+            continue
+        errors.append("%s: unsupported mock config provider" % provider)
+    raise MockConfigUnavailable(errors)
 
 
 def _without_none(data):
@@ -109,12 +162,25 @@ def _build_environment_summary(
     mock_cfg=None,
     repo_fallback=None,
     executor=None,
+    profile=None,
+    profile_candidates=None,
+    artifact_locator=None,
+    mock_config_source=None,
+    executor_policy=None,
+    tls_mode=None,
 ):
     buildroot = resolution.buildroot if resolution else {}
     environment = {
         "executor": executor or _environment_executor_summary(args),
         "koji_server": args.koji_server,
         "koji_topurl": args.koji_topurl,
+        "koji_profile_id": profile.id if profile else None,
+        "profile_source": profile.source if profile else None,
+        "profile_candidates": profile_candidates,
+        "artifact_locator": artifact_locator,
+        "mock_config_source": mock_config_source,
+        "executor_policy": executor_policy,
+        "tls_mode": tls_mode,
         "buildroot_id": buildroot.get("id"),
         "buildroot_tag": buildroot.get("tag_name"),
         "buildroot_arch": buildroot.get("arch"),
@@ -312,7 +378,12 @@ def run_koji_rpm_rebuild(args):
         print("--runs must be >= 1", file=sys.stderr)
         return 2
 
-    executor = getattr(args, "executor", "vm")
+    requested_executor = getattr(args, "executor", "auto")
+    tls_config = build_tls_config(
+        [getattr(args, "koji_server", None), getattr(args, "koji_topurl", None)],
+        ca_cert=getattr(args, "koji_ca_cert", None),
+        insecure=getattr(args, "koji_insecure_ssl", False),
+    )
 
     run_dir = _run_dir(args.workdir, args.rpm_name)
     inputs_dir = run_dir / "inputs"
@@ -329,19 +400,40 @@ def run_koji_rpm_rebuild(args):
             "analysis_time": _analysis_time(),
         },
         "input_artifacts": {},
-        "build_environment": _build_environment_summary(args),
+        "build_environment": _build_environment_summary(args, tls_mode=tls_config.mode),
         "rebuild": _rebuild_summary(args, "started"),
         "analysis": _analysis_summary(),
     }
 
     try:
         rpm_info = parse_rpm_filename(args.rpm_name)
-        client = KojiClient(args.koji_server)
+        client = KojiClient(args.koji_server, ssl_context=tls_config.ssl_context)
         resolution = resolve_koji_build(client, rpm_info)
         target_rpm_name = rpm_filename(resolution.rpm)
-        target_os = detect_target_os(rpm_info, resolution.buildroot)
+        profile, profile_candidates = select_koji_profile(
+            getattr(args, "koji_profile", "auto"),
+            getattr(args, "koji_profile_file", None),
+            args,
+            rpm_info,
+            resolution,
+        )
+        target_os = profile.target_os or detect_target_os(rpm_info, resolution.buildroot)
+        executor = profile.resolve_executor(requested_executor)
+        executor_policy = {
+            "requested": requested_executor,
+            "selected": executor,
+            "profile_default": profile.executor_policy,
+            "supported_executors": profile.supported_executors,
+        }
 
-        if executor == "vm" and not is_supported_target_os(target_os):
+        unsupported_executor = not profile.supports_executor(executor)
+        unsupported_vm_target = executor == "vm" and not is_supported_target_os(target_os)
+        if unsupported_executor or unsupported_vm_target:
+            unsupported_executor_summary = (
+                vm_executor_summary(target_os=target_os)
+                if executor == "vm"
+                else {"mode": executor}
+            )
             report = {
                 "version": ASSESSMENT_VERSION,
                 "metadata": {
@@ -352,20 +444,28 @@ def run_koji_rpm_rebuild(args):
                 "build_environment": _build_environment_summary(
                     args,
                     resolution=resolution,
-                    executor=vm_executor_summary(target_os=target_os),
+                    executor=unsupported_executor_summary,
+                    profile=profile,
+                    profile_candidates=profile_candidates,
+                    executor_policy=executor_policy,
+                    tls_mode=tls_config.mode,
                 ),
                 "rebuild": _rebuild_summary(
                     args,
                     "unsupported",
-                    reason="only an23 Koji RPM rebuild is currently supported by the VM executor",
+                    reason=(
+                        "the selected Koji profile does not support executor %s" % executor
+                        if unsupported_executor
+                        else "only an23 Koji RPM rebuild is currently supported by the VM executor"
+                    ),
                 ),
                 "analysis": _analysis_summary(),
             }
             report.update(_unavailable_assessment("unsupported_target"))
             write_json(run_dir / "report.json", report)
             print(
-                "[guanfu] Unsupported Koji RPM target for VM executor: "
-                f"tag={resolution.buildroot.get('tag_name')!r}",
+                "[guanfu] Unsupported Koji RPM target for executor "
+                f"{executor!r}: profile={profile.id!r} tag={resolution.buildroot.get('tag_name')!r}",
                 file=sys.stderr,
             )
             return 3
@@ -376,23 +476,30 @@ def run_koji_rpm_rebuild(args):
         write_json(metadata_dir / "buildarch-task.json", resolution.buildarch_task)
         write_json(metadata_dir / "task-result.json", resolution.task_result)
 
-        repo_probe = probe_repodata(args.koji_topurl, resolution.buildroot)
+        repo_probe = probe_repodata(
+            args.koji_topurl,
+            resolution.buildroot,
+            ssl_context=tls_config.ssl_context,
+            repo_url_template=profile.repo_url_template,
+        )
         write_json(metadata_dir / "repo-probe.json", repo_probe)
 
-        published_rpm_url = join_url(args.binary_rpm_base_url, target_rpm_name)
+        published_rpm_url, binary_artifact_locator = profile.binary_rpm_url(args, resolution, target_rpm_name)
         published_rpm, published_rpm_summary = _download_published(
             published_rpm_url,
             inputs_dir / target_rpm_name,
             "published_rpm",
+            ssl_context=tls_config.ssl_context,
         )
         if not published_rpm:
             raise RuntimeError(f"failed to download published RPM: {published_rpm_summary}")
 
-        published_srpm_url = join_url(args.source_rpm_base_url, resolution.task_srpm_name)
+        published_srpm_url, source_artifact_locator = profile.source_rpm_url(args, resolution)
         published_srpm, published_srpm_summary = _download_published(
             published_srpm_url,
             inputs_dir / resolution.task_srpm_name,
             "published_srpm",
+            ssl_context=tls_config.ssl_context,
         )
 
         task_srpm, task_srpm_summary = _download_task_srpm(
@@ -422,14 +529,76 @@ def run_koji_rpm_rebuild(args):
         srpm_cross_check = compare_srpms(published_srpm, task_srpm)
 
         mock_cfg = inputs_dir / "mock.cfg"
-        generate_mock_config(
-            args.koji_server,
-            args.koji_topurl,
-            resolution.buildroot["id"],
-            mock_cfg,
-        )
+        try:
+            mock_cfg, mock_config_source = _prepare_mock_config(
+                profile,
+                client,
+                args,
+                resolution,
+                inputs_dir,
+                mock_cfg,
+            )
+        except MockConfigUnavailable as exc:
+            report = {
+                "version": ASSESSMENT_VERSION,
+                "metadata": {
+                    "package_name": target_rpm_name,
+                    "reference_url": published_rpm_url,
+                    "reference_sha256": published_rpm_summary.get("sha256"),
+                    "rebuild_sha256": None,
+                    "analysis_time": _analysis_time(),
+                },
+                "input_artifacts": _input_artifacts_summary(
+                    published_rpm_summary=published_rpm_summary,
+                    task_srpm_summary=task_srpm_summary,
+                    log_summaries=log_summaries,
+                    source_rpm_summary=source_rpm_summary,
+                    source_rpm_type=source_rpm_type,
+                    source_rpm_url=source_rpm_url,
+                    task_id=resolution.buildarch_task["id"],
+                    srpm_cross_check=srpm_cross_check,
+                ),
+                "build_environment": _build_environment_summary(
+                    args,
+                    resolution=resolution,
+                    repo_probe=repo_probe,
+                    profile=profile,
+                    profile_candidates=profile_candidates,
+                    artifact_locator={
+                        "binary": binary_artifact_locator,
+                        "source": source_artifact_locator,
+                    },
+                    mock_config_source={"status": "unavailable", "errors": exc.errors},
+                    executor_policy=executor_policy,
+                    tls_mode=tls_config.mode,
+                ),
+                "rebuild": _rebuild_summary(
+                    args,
+                    "skipped",
+                    reason="mock_config_unavailable",
+                    error=repr(exc),
+                ),
+                "analysis": _analysis_summary(),
+            }
+            report.update(_unavailable_assessment("mock_config_unavailable"))
+            write_json(run_dir / "report.json", report)
+            print("[guanfu] Mock config is unavailable", file=sys.stderr)
+            return 3
         active_mock_cfg = mock_cfg
         repo_fallback = None
+        artifact_locator_summary = {
+            "binary": binary_artifact_locator,
+            "source": source_artifact_locator,
+        }
+        environment_context = {
+            "profile": profile,
+            "profile_candidates": profile_candidates,
+            "artifact_locator": artifact_locator_summary,
+            "mock_config_source": mock_config_source,
+            "executor_policy": executor_policy,
+            "tls_mode": tls_config.mode,
+        }
+        selected_executor_summary = {"mode": executor}
 
         if repo_probe.get("status") != 200:
             if getattr(args, "repo_fallback", "installed-pkgs") == "none":
@@ -460,8 +629,9 @@ def run_koji_rpm_rebuild(args):
                         executor=(
                             vm_executor_summary(target_os=target_os, koji_recorded=koji_recorded_env)
                             if executor == "vm"
-                            else None
+                            else selected_executor_summary
                         ),
+                        **environment_context,
                     ),
                     "rebuild": _rebuild_summary(
                         args,
@@ -504,6 +674,7 @@ def run_koji_rpm_rebuild(args):
                         run_dir / "fallback-repo",
                         metadata_dir,
                         resolution.buildarch_task["id"],
+                        ssl_context=tls_config.ssl_context,
                     )
                 except Exception as exc:
                     repo_fallback = {
@@ -558,8 +729,9 @@ def run_koji_rpm_rebuild(args):
                         executor=(
                             vm_executor_summary(target_os=target_os, koji_recorded=koji_recorded_env)
                             if executor == "vm"
-                            else None
+                            else selected_executor_summary
                         ),
+                        **environment_context,
                     ),
                     "rebuild": _rebuild_summary(
                         args,
@@ -578,7 +750,7 @@ def run_koji_rpm_rebuild(args):
 
             active_mock_cfg = inputs_dir / "mock-fallback-installed-pkgs.cfg"
 
-        executor_details = None
+        executor_details = selected_executor_summary if executor == "local" else None
         if executor == "vm":
             vm_result = run_vm_rebuild(
                 args,
@@ -594,6 +766,58 @@ def run_koji_rpm_rebuild(args):
             if rebuilds and rebuilds[-1]["exit_code"] != 0:
                 _print_rebuild_failure_diagnosis(rebuilds[-1])
         else:
+            if not shutil.which("mock"):
+                executor_details = {
+                    "mode": "local",
+                    "preflight": {
+                        "checks": [
+                            {
+                                "name": "mock",
+                                "status": "missing",
+                                "hint": "Install mock before using the local Koji rebuild executor.",
+                            }
+                        ]
+                    },
+                }
+                report = {
+                    "version": ASSESSMENT_VERSION,
+                    "metadata": {
+                        "package_name": target_rpm_name,
+                        "reference_url": published_rpm_url,
+                        "reference_sha256": published_rpm_summary.get("sha256"),
+                        "rebuild_sha256": None,
+                        "analysis_time": _analysis_time(),
+                    },
+                    "input_artifacts": _input_artifacts_summary(
+                        published_rpm_summary=published_rpm_summary,
+                        task_srpm_summary=task_srpm_summary,
+                        log_summaries=log_summaries,
+                        source_rpm_summary=source_rpm_summary,
+                        source_rpm_type=source_rpm_type,
+                        source_rpm_url=source_rpm_url,
+                        task_id=resolution.buildarch_task["id"],
+                        srpm_cross_check=srpm_cross_check,
+                    ),
+                    "build_environment": _build_environment_summary(
+                        args,
+                        resolution=resolution,
+                        repo_probe=repo_probe,
+                        mock_cfg=active_mock_cfg,
+                        repo_fallback=repo_fallback,
+                        executor=executor_details,
+                        **environment_context,
+                    ),
+                    "rebuild": _rebuild_summary(
+                        args,
+                        "skipped",
+                        reason="local mock executable is not available",
+                    ),
+                    "analysis": _analysis_summary(),
+                }
+                report.update(_unavailable_assessment("mock_tool"))
+                write_json(run_dir / "report.json", report)
+                print("[guanfu] Local executor requires mock", file=sys.stderr)
+                return 3
             rebuilds = []
             for run_index in range(1, args.runs + 1):
                 resultdir = results_dir / f"result-run-{run_index}"
@@ -641,6 +865,7 @@ def run_koji_rpm_rebuild(args):
                     mock_cfg=active_mock_cfg,
                     repo_fallback=repo_fallback,
                     executor=executor_details,
+                    **environment_context,
                 ),
                 "rebuild": _rebuild_summary(
                     args,
@@ -680,6 +905,7 @@ def run_koji_rpm_rebuild(args):
                     mock_cfg=active_mock_cfg,
                     repo_fallback=repo_fallback,
                     executor=executor_details,
+                    **environment_context,
                 ),
                 "rebuild": _rebuild_summary(args, "failed", rebuilds=rebuilds),
                 "analysis": _analysis_summary(),

--- a/src/guanfu/koji_rebuild/downloader.py
+++ b/src/guanfu/koji_rebuild/downloader.py
@@ -1,10 +1,29 @@
 import base64
 import hashlib
+import ssl
 import urllib.error
 import urllib.parse
 import urllib.request
 import xmlrpc.client
 from pathlib import Path
+
+
+class TLSConfig:
+    def __init__(self, mode, ssl_context=None):
+        self.mode = mode
+        self.ssl_context = ssl_context
+
+
+def build_tls_config(urls, ca_cert=None, insecure=False):
+    urls = [url for url in (urls or []) if url]
+    uses_https = any(urllib.parse.urlparse(str(url)).scheme == "https" for url in urls)
+    if not uses_https:
+        return TLSConfig("plain-http")
+    if insecure:
+        return TLSConfig("insecure", ssl._create_unverified_context())
+    if ca_cert:
+        return TLSConfig("custom-ca", ssl.create_default_context(cafile=str(ca_cert)))
+    return TLSConfig("system-ca", ssl.create_default_context())
 
 
 def sha256_file(path):
@@ -36,11 +55,14 @@ def join_url(base_url, filename):
     return urllib.parse.urljoin(base_url, urllib.parse.quote(filename))
 
 
-def download_url(url, dest):
+def download_url(url, dest, ssl_context=None):
     dest = Path(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     request = urllib.request.Request(url, headers={"User-Agent": "guanfu-koji-rebuild/0.1"})
-    with urllib.request.urlopen(request, timeout=60) as response:
+    kwargs = {"timeout": 60}
+    if ssl_context is not None:
+        kwargs["context"] = ssl_context
+    with urllib.request.urlopen(request, **kwargs) as response:
         with open(dest, "wb") as f:
             while True:
                 chunk = response.read(1024 * 1024)
@@ -50,9 +72,9 @@ def download_url(url, dest):
     return dest
 
 
-def try_download_url(url, dest):
+def try_download_url(url, dest, ssl_context=None):
     try:
-        return download_url(url, dest), None
+        return download_url(url, dest, ssl_context=ssl_context), None
     except urllib.error.HTTPError as exc:
         return None, f"HTTP {exc.code}: {exc.reason}"
     except Exception as exc:

--- a/src/guanfu/koji_rebuild/mock_config.py
+++ b/src/guanfu/koji_rebuild/mock_config.py
@@ -5,20 +5,27 @@ import urllib.request
 from pathlib import Path
 
 
-def historical_repo_url(koji_topurl, buildroot):
+def historical_repo_url(koji_topurl, buildroot, repo_url_template=None):
     topurl = koji_topurl.rstrip("/")
+    if repo_url_template:
+        values = dict(buildroot or {})
+        values["topurl"] = topurl
+        return repo_url_template.format(**values)
     return (
         f"{topurl}/repos/{buildroot['tag_name']}/"
         f"{buildroot['repo_id']}/{buildroot['arch']}"
     )
 
 
-def probe_repodata(koji_topurl, buildroot):
-    repo_url = historical_repo_url(koji_topurl, buildroot)
+def probe_repodata(koji_topurl, buildroot, ssl_context=None, repo_url_template=None):
+    repo_url = historical_repo_url(koji_topurl, buildroot, repo_url_template=repo_url_template)
     repomd_url = f"{repo_url}/repodata/repomd.xml"
     try:
         request = urllib.request.Request(repomd_url, method="GET")
-        with urllib.request.urlopen(request, timeout=20) as response:
+        kwargs = {"timeout": 20}
+        if ssl_context is not None:
+            kwargs["context"] = ssl_context
+        with urllib.request.urlopen(request, **kwargs) as response:
             response.read(64)
             return {"url": repomd_url, "status": response.status}
     except urllib.error.HTTPError as exc:

--- a/src/guanfu/koji_rebuild/profiles.py
+++ b/src/guanfu/koji_rebuild/profiles.py
@@ -1,0 +1,191 @@
+import re
+import urllib.parse
+from pathlib import Path
+
+from guanfu.koji_rebuild.downloader import join_url
+
+
+OPENANOLIS_BINARY_RPM_BASE_URL = "https://mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/"
+OPENANOLIS_SOURCE_RPM_BASE_URL = "https://mirrors.openanolis.cn/anolis/23/os/source/Packages/"
+
+
+class KojiProfile:
+    def __init__(
+        self,
+        profile_id,
+        match_rules=None,
+        artifact_locator="koji-topurl-packages",
+        binary_rpm_base_url=None,
+        source_rpm_base_url=None,
+        mock_config_providers=None,
+        executor_policy="local",
+        supported_executors=None,
+        repo_url_template=None,
+        target_os=None,
+        source="builtin",
+    ):
+        self.id = profile_id
+        self.match_rules = match_rules or {}
+        self.artifact_locator = artifact_locator
+        self.binary_rpm_base_url = binary_rpm_base_url
+        self.source_rpm_base_url = source_rpm_base_url
+        self.mock_config_providers = mock_config_providers or ["koji-cli"]
+        self.executor_policy = executor_policy
+        self.supported_executors = supported_executors or [executor_policy]
+        self.repo_url_template = repo_url_template
+        self.target_os = target_os
+        self.source = source
+
+    def matches(self, args, rpm_info, resolution):
+        rules = self.match_rules or {}
+        if rules.get("always"):
+            return True
+        if rules.get("target_os") == "an23":
+            tag = ((resolution.buildroot or {}).get("tag_name") or "").lower()
+            release = ((rpm_info or {}).get("release") or "").lower()
+            return _has_an23_marker(tag) or _has_an23_marker(release)
+
+        checks = []
+        if "release_regex" in rules:
+            checks.append(_matches_regex(rules["release_regex"], (rpm_info or {}).get("release")))
+        if "tag_regex" in rules:
+            checks.append(_matches_regex(rules["tag_regex"], (resolution.buildroot or {}).get("tag_name")))
+        if "name_regex" in rules:
+            checks.append(_matches_regex(rules["name_regex"], (rpm_info or {}).get("name")))
+        if "server_regex" in rules:
+            checks.append(_matches_regex(rules["server_regex"], getattr(args, "koji_server", "")))
+        return bool(checks) and all(checks)
+
+    def resolve_executor(self, requested):
+        if requested in (None, "auto"):
+            return self.executor_policy
+        return requested
+
+    def supports_executor(self, executor):
+        return executor in (self.supported_executors or [])
+
+    def binary_rpm_url(self, args, resolution, target_rpm_name):
+        explicit_base = getattr(args, "binary_rpm_base_url", None)
+        if explicit_base:
+            return join_url(explicit_base, target_rpm_name), "explicit-base-url"
+        if self.binary_rpm_base_url:
+            return join_url(self.binary_rpm_base_url, target_rpm_name), "profile-base-url"
+        return _koji_packages_url(getattr(args, "koji_topurl"), resolution.build, resolution.rpm["arch"], target_rpm_name), self.artifact_locator
+
+    def source_rpm_url(self, args, resolution):
+        explicit_base = getattr(args, "source_rpm_base_url", None)
+        if explicit_base:
+            return join_url(explicit_base, resolution.task_srpm_name), "explicit-base-url"
+        if self.source_rpm_base_url:
+            return join_url(self.source_rpm_base_url, resolution.task_srpm_name), "profile-base-url"
+        return _koji_packages_url(getattr(args, "koji_topurl"), resolution.build, "src", resolution.task_srpm_name), self.artifact_locator
+
+
+def load_koji_profiles(paths):
+    profiles = []
+    for path in paths or []:
+        profiles.extend(_load_profile_file(path))
+    profiles.extend(_builtin_profiles())
+    return profiles
+
+
+def select_koji_profile(requested, profile_files, args, rpm_info, resolution):
+    profiles = load_koji_profiles(profile_files)
+    requested = requested or "auto"
+    if requested != "auto":
+        for profile in profiles:
+            if profile.id == requested:
+                return profile, [profile.id]
+        raise RuntimeError("Koji profile was not found: %s" % requested)
+
+    candidates = [profile for profile in profiles if profile.matches(args, rpm_info, resolution)]
+    if candidates:
+        return candidates[0], [profile.id for profile in candidates]
+    generic = next((profile for profile in profiles if profile.id == "generic-koji"), None)
+    if not generic:
+        raise RuntimeError("generic-koji profile was not found")
+    return generic, [generic.id]
+
+
+def _builtin_profiles():
+    return [
+        KojiProfile(
+            "openanolis-an23",
+            match_rules={"target_os": "an23"},
+            artifact_locator="profile-base-url",
+            binary_rpm_base_url=OPENANOLIS_BINARY_RPM_BASE_URL,
+            source_rpm_base_url=OPENANOLIS_SOURCE_RPM_BASE_URL,
+            mock_config_providers=["koji-cli"],
+            executor_policy="vm",
+            supported_executors=["vm", "local"],
+            target_os="an23",
+            source="builtin",
+        ),
+        KojiProfile(
+            "generic-koji",
+            match_rules={"always": True},
+            artifact_locator="koji-topurl-packages",
+            mock_config_providers=["task-output-mock-config", "koji-cli"],
+            executor_policy="local",
+            supported_executors=["local"],
+            source="builtin",
+        ),
+    ]
+
+
+def _load_profile_file(path):
+    path = Path(path).expanduser()
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to load Koji profile files") from exc
+    with path.open() as handle:
+        data = yaml.safe_load(handle) or {}
+    raw_profiles = data.get("profiles", data if isinstance(data, list) else [])
+    profiles = []
+    for item in raw_profiles:
+        if not isinstance(item, dict) or not item.get("id"):
+            raise RuntimeError("Koji profile entries must be mappings with an id")
+        profiles.append(
+            KojiProfile(
+                item["id"],
+                match_rules=item.get("match_rules") or item.get("match") or {},
+                artifact_locator=item.get("artifact_locator", "koji-topurl-packages"),
+                binary_rpm_base_url=item.get("binary_rpm_base_url"),
+                source_rpm_base_url=item.get("source_rpm_base_url"),
+                mock_config_providers=item.get("mock_config_providers"),
+                executor_policy=item.get("executor_policy", "local"),
+                supported_executors=item.get("supported_executors"),
+                repo_url_template=item.get("repo_url_template"),
+                target_os=item.get("target_os"),
+                source=str(path),
+            )
+        )
+    return profiles
+
+
+def _koji_packages_url(topurl, build, arch, filename):
+    base = "{topurl}/packages/{name}/{version}/{release}/{arch}/".format(
+        topurl=str(topurl).rstrip("/"),
+        name=_quote_path(build["name"]),
+        version=_quote_path(build["version"]),
+        release=_quote_path(build["release"]),
+        arch=_quote_path(arch),
+    )
+    return join_url(base, filename)
+
+
+def _quote_path(value):
+    return urllib.parse.quote(str(value), safe="")
+
+
+def _matches_regex(pattern, value):
+    if value is None:
+        return False
+    return bool(re.search(pattern, str(value)))
+
+
+def _has_an23_marker(value):
+    if not value:
+        return False
+    return bool(re.search(r"(^|[^a-z0-9])an23([^a-z0-9]|$)", value))

--- a/src/guanfu/koji_rebuild/repo_fallback.py
+++ b/src/guanfu/koji_rebuild/repo_fallback.py
@@ -64,8 +64,8 @@ def _url_join(base, href):
     return urllib.parse.urljoin(base, href)
 
 
-def _download_metadata(url, dest):
-    path = download_url(url, dest)
+def _download_metadata(url, dest, ssl_context=None):
+    path = download_url(url, dest, ssl_context=ssl_context)
     return summarize_file(path, label="external_repo_metadata", url=url)
 
 
@@ -227,7 +227,7 @@ def _repo_event(buildroot):
     return buildroot.get("repo_create_event_id") or buildroot.get("create_event_id")
 
 
-def _external_repo_metadata(client, buildroot, metadata_dir):
+def _external_repo_metadata(client, buildroot, metadata_dir, ssl_context=None):
     event = _repo_event(buildroot)
     repos = client.get_external_repo_list(buildroot["tag_name"], event)
     arch = buildroot["arch"]
@@ -241,10 +241,10 @@ def _external_repo_metadata(client, buildroot, metadata_dir):
         item["resolved_url"] = base_url
         try:
             repomd_url = _url_join(base_url, "repodata/repomd.xml")
-            repomd = _download_metadata(repomd_url, repo_dir / "repomd.xml")
+            repomd = _download_metadata(repomd_url, repo_dir / "repomd.xml", ssl_context=ssl_context)
             primary_info = _find_primary_location(repo_dir / "repomd.xml")
             primary_url = _url_join(base_url, primary_info["href"])
-            primary = _download_metadata(primary_url, repo_dir / Path(primary_info["href"]).name)
+            primary = _download_metadata(primary_url, repo_dir / Path(primary_info["href"]).name, ssl_context=ssl_context)
             item["repomd"] = repomd
             item["primary"] = primary
             item["primary_info"] = primary_info
@@ -270,8 +270,8 @@ def _find_external_package(repo_metadata, entry):
     return None, None
 
 
-def _recover_external_rpms(client, buildroot, entries, repo_dir, metadata_dir):
-    repo_metadata = _external_repo_metadata(client, buildroot, metadata_dir)
+def _recover_external_rpms(client, buildroot, entries, repo_dir, metadata_dir, ssl_context=None):
+    repo_metadata = _external_repo_metadata(client, buildroot, metadata_dir, ssl_context=ssl_context)
     report = {
         "status": "ready",
         "event_id": _repo_event(buildroot),
@@ -295,7 +295,7 @@ def _recover_external_rpms(client, buildroot, entries, repo_dir, metadata_dir):
         artifact = downloaded_cache.get(source_url)
         if artifact is None:
             try:
-                download_url(source_url, path)
+                download_url(source_url, path, ssl_context=ssl_context)
                 artifact = summarize_file(path, label="recovered_external_rpm", url=source_url)
                 artifact["source_type"] = "external_repo"
                 artifact["external_repo_name"] = repo["external_repo_name"]
@@ -636,6 +636,7 @@ def prepare_installed_pkgs_fallback(
     repo_dir,
     metadata_dir,
     source_task_id,
+    ssl_context=None,
 ):
     installed_pkgs_log = Path(installed_pkgs_log)
     repo_dir = Path(repo_dir)
@@ -712,6 +713,7 @@ def prepare_installed_pkgs_fallback(
             unresolved_by_getrpm,
             repo_dir,
             metadata_dir,
+            ssl_context=ssl_context,
         )
         for item in external_resolved:
             parsed = _parse_nevra(item["entry"]["rpm_lookup"])

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,161 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from guanfu.koji_rebuild.command import _prepare_mock_config, run_koji_rpm_rebuild
+from guanfu.koji_rebuild.downloader import build_tls_config
+from guanfu.koji_rebuild.profiles import load_koji_profiles, select_koji_profile
+
+
+def _resolution(tag="dist", release="21.al8"):
+    return SimpleNamespace(
+        buildroot={"tag_name": tag},
+        build={
+            "name": "anothertest",
+            "version": "1.0.0",
+            "release": release,
+        },
+        rpm={
+            "name": "anothertest",
+            "version": "1.0.0",
+            "release": release,
+            "arch": "x86_64",
+        },
+        task_srpm_name="anothertest-1.0.0-%s.src.rpm" % release,
+        outputs={},
+        buildarch_task={"id": 193},
+    )
+
+
+class KojiProfileTests(unittest.TestCase):
+    def test_auto_profile_prefers_openanolis_an23(self):
+        args = SimpleNamespace(koji_server="https://build.openanolis.cn/kojihub", koji_topurl="https://build.openanolis.cn/kojifiles")
+        rpm_info = {"name": "zlib", "release": "3.an23"}
+
+        profile, candidates = select_koji_profile("auto", [], args, rpm_info, _resolution(tag="dist-an23.0-build"))
+
+        self.assertEqual(profile.id, "openanolis-an23")
+        self.assertIn("openanolis-an23", candidates)
+        self.assertEqual(profile.resolve_executor("auto"), "vm")
+
+    def test_auto_profile_falls_back_to_generic(self):
+        args = SimpleNamespace(koji_server="http://koji.example/kojihub", koji_topurl="http://koji.example/kojifiles")
+        rpm_info = {"name": "sample", "release": "1.al8"}
+
+        profile, candidates = select_koji_profile("auto", [], args, rpm_info, _resolution(tag="dist"))
+
+        self.assertEqual(profile.id, "generic-koji")
+        self.assertEqual(candidates, ["generic-koji"])
+        self.assertEqual(profile.resolve_executor("auto"), "local")
+        self.assertFalse(profile.supports_executor("vm"))
+
+    def test_openanolis_profile_keeps_existing_mirror_defaults(self):
+        args = SimpleNamespace(binary_rpm_base_url=None, source_rpm_base_url=None, koji_topurl="https://build.openanolis.cn/kojifiles")
+        profile = [item for item in load_koji_profiles([]) if item.id == "openanolis-an23"][0]
+
+        binary_url, binary_locator = profile.binary_rpm_url(args, _resolution(release="3.an23"), "zlib-1.2.13-3.an23.x86_64.rpm")
+        source_url, source_locator = profile.source_rpm_url(args, _resolution(release="3.an23"))
+
+        self.assertEqual(binary_locator, "profile-base-url")
+        self.assertIn("mirrors.openanolis.cn/anolis/23/os/x86_64/os/Packages/zlib-1.2.13-3.an23.x86_64.rpm", binary_url)
+        self.assertEqual(source_locator, "profile-base-url")
+        self.assertIn("mirrors.openanolis.cn/anolis/23/os/source/Packages/anothertest-1.0.0-3.an23.src.rpm", source_url)
+
+    def test_generic_profile_derives_koji_packages_urls(self):
+        args = SimpleNamespace(binary_rpm_base_url=None, source_rpm_base_url=None, koji_topurl="http://koji.example/kojifiles")
+        profile = [item for item in load_koji_profiles([]) if item.id == "generic-koji"][0]
+        resolution = _resolution(release="21.al8")
+
+        binary_url, binary_locator = profile.binary_rpm_url(args, resolution, "anothertest-1.0.0-21.al8.x86_64.rpm")
+        source_url, source_locator = profile.source_rpm_url(args, resolution)
+
+        self.assertEqual(binary_locator, "koji-topurl-packages")
+        self.assertEqual(binary_url, "http://koji.example/kojifiles/packages/anothertest/1.0.0/21.al8/x86_64/anothertest-1.0.0-21.al8.x86_64.rpm")
+        self.assertEqual(source_locator, "koji-topurl-packages")
+        self.assertEqual(source_url, "http://koji.example/kojifiles/packages/anothertest/1.0.0/21.al8/src/anothertest-1.0.0-21.al8.src.rpm")
+
+    def test_profile_file_has_priority_in_auto_selection(self):
+        try:
+            import yaml  # noqa: F401
+        except ImportError:
+            self.skipTest("PyYAML is not installed")
+        with tempfile.TemporaryDirectory() as tmp:
+            profile_file = Path(tmp) / "profiles.yaml"
+            profile_file.write_text(
+                "profiles:\n"
+                "  - id: custom-koji\n"
+                "    match_rules:\n"
+                "      tag_regex: '^dist$'\n"
+                "    executor_policy: local\n"
+                "    mock_config_providers: [task-output-mock-config]\n"
+            )
+            args = SimpleNamespace(koji_server="http://koji.example/kojihub", koji_topurl="http://koji.example/kojifiles")
+
+            profile, candidates = select_koji_profile("auto", [str(profile_file)], args, {"release": "1.al8"}, _resolution(tag="dist"))
+
+        self.assertEqual(profile.id, "custom-koji")
+        self.assertEqual(candidates[0], "custom-koji")
+
+    def test_mock_config_log_provider_does_not_require_koji_cli(self):
+        profile = [item for item in load_koji_profiles([]) if item.id == "generic-koji"][0]
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs = Path(tmp)
+            (inputs / "mock_config.log").write_text("config_opts['root'] = 'dist-67-16'\n")
+            mock_cfg = inputs / "mock.cfg"
+
+            path, source = _prepare_mock_config(
+                profile,
+                client=None,
+                args=SimpleNamespace(koji_server="http://koji.example/kojihub", koji_topurl="http://koji.example/kojifiles"),
+                resolution=_resolution(),
+                inputs_dir=inputs,
+                mock_cfg=mock_cfg,
+            )
+            contents = mock_cfg.read_text()
+
+        self.assertEqual(path, mock_cfg)
+        self.assertEqual(source["provider"], "task-output-mock-config")
+        self.assertEqual(contents, "config_opts['root'] = 'dist-67-16'\n")
+
+    def test_tls_modes(self):
+        self.assertEqual(build_tls_config(["http://koji.example/kojihub"]).mode, "plain-http")
+        self.assertEqual(build_tls_config(["https://koji.example/kojihub"], insecure=True).mode, "insecure")
+        self.assertEqual(build_tls_config(["https://koji.example/kojihub"]).mode, "system-ca")
+
+    def test_generic_profile_rejects_explicit_vm_executor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args = SimpleNamespace(
+                slsa_provenance=None,
+                runs=1,
+                workdir=tmp,
+                rpm_name="anothertest-1.0.0-21.al8.x86_64.rpm",
+                koji_server="http://koji.example/kojihub",
+                koji_topurl="http://koji.example/kojifiles",
+                koji_profile="generic-koji",
+                koji_profile_file=[],
+                koji_ca_cert=None,
+                koji_insecure_ssl=False,
+                binary_rpm_base_url=None,
+                source_rpm_base_url=None,
+                executor="vm",
+                repo_fallback="none",
+                isolation="simple",
+            )
+            with patch("guanfu.koji_rebuild.command.KojiClient"), patch(
+                "guanfu.koji_rebuild.command.resolve_koji_build",
+                return_value=_resolution(tag="dist", release="21.al8"),
+            ):
+                rc = run_koji_rpm_rebuild(args)
+            report = json.loads((Path(tmp) / "anothertest-1.0.0-21.al8.x86_64.rpm" / "report.json").read_text())
+
+        self.assertEqual(rc, 3)
+        self.assertEqual(report["build_environment"]["koji_profile_id"], "generic-koji")
+        self.assertEqual(report["rebuild"]["status"], "unsupported")
+        self.assertIn("does not support executor vm", report["rebuild"]["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add profile-driven Koji rebuild support with built-in OpenAnolis and generic Koji profiles
- support external YAML profiles, Koji TLS options, profile-selected artifact URLs, mock config providers, and executor policies
- record profile/TLS/executor/mock config details in reports and document generic Koji usage

## Testing
- PYTHONPATH=src python3 -m pytest -q
- python3 -m compileall -q src
- integration verified against koji-internal.jinzihao.me using guanfu-rebuild-smoke-1.0-1.gf20260522153059.al8.x86_64.rpm on remote local mock executor