### PR TITLE
release: fix jq --argfile removed in jq 1.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,16 +318,16 @@ jobs:
               exit 1
             fi
             jq -n \
-              --argfile releasePayload release-manifest/release_payload.json \
-              --argfile dsse release-manifest/release.dsse.json \
-              --argfile rekor release-manifest/rekor-v1-entry.json \
-              '{releasePayload:$releasePayload,dsseEnvelope:$dsse,rekorEntryV1:$rekor}' \
+              --slurpfile releasePayload release-manifest/release_payload.json \
+              --slurpfile dsse release-manifest/release.dsse.json \
+              --slurpfile rekor release-manifest/rekor-v1-entry.json \
+              '{releasePayload:$releasePayload[0],dsseEnvelope:$dsse[0],rekorEntryV1:$rekor[0]}' \
               > "release-manifest/${BUNDLE_NAME}"
           else
             jq -n \
-              --argfile releasePayload release-manifest/release_payload.json \
-              --argfile dsse release-manifest/release.dsse.json \
-              '{releasePayload:$releasePayload,dsseEnvelope:$dsse}' \
+              --slurpfile releasePayload release-manifest/release_payload.json \
+              --slurpfile dsse release-manifest/release.dsse.json \
+              '{releasePayload:$releasePayload[0],dsseEnvelope:$dsse[0]}' \
               > "release-manifest/${BUNDLE_NAME}"
           fi
 


### PR DESCRIPTION
## Problem

\`release.yml\` invokes \`jq --argfile\` to bundle the RV release manifest. \`--argfile\` was deprecated in jq 1.4 and **removed in jq 1.7** (released 2023-09). GitHub-hosted \`ubuntu-latest\` runners now ship jq 1.7+, so the \`Generate RV release manifest DSSE\` step fails with:

\`\`\`
jq: Unknown option --argfile
##[error]Process completed with exit code 2.
\`\`\`

This breaks every consumer of \`1570005763/GuanFu/.github/workflows/release.yml@v1\` whenever \`UPLOAD_TO_REKOR\` is true (and the \`else\` branch when it's false). Recently observed on:

- openanolis/trustee v1.8.4 release workflow
- inclavare-containers/guest-components v1.5.1 release workflow

## Fix

Switch the three \`--argfile NAME PATH\` calls to \`--slurpfile NAME PATH\` (the supported replacement) and dereference \`[0]\` in the jq expression so the emitted JSON is byte-identical.

## Notes

- No semantic change in output — \`--slurpfile\` produces \`[<contents>]\` and indexing \`[0]\` collapses it back to the original value.
- After merge, the \`v1\` tag should be force-updated to this commit so existing consumers pick up the fix without bumping their \`@v1\` ref.