### PR TITLE
[codex] Use deterministic gzip source RPM payload

### DIFF
--- a/docs/buildspec.md
+++ b/docs/buildspec.md
@@ -45,6 +45,12 @@ environment:
       version: "1.1.1k"
     - name: "zlib-devel"
       version: "1.2.11"
+    - name: "rpm-build"
+      version: "4.14.3-32.0.1.1.al8"
+    - name: "rpm-libs"
+      version: "4.14.3-32.0.1.1.al8"
+    - name: "zlib"
+      version: "1.2.11-20.9.al8.alnx"
   tools:
     - name: "node"
       version: "18.x"
@@ -171,6 +177,33 @@ environment:
 
 - 在非 Anolis 23 OS 下，当前版本的 runner 会直接报错（未实现）。
 
+对于 RPM 可重复构建，建议显式声明并固定压缩相关工具链：
+
+```yaml
+environment:
+  systemPackages:
+    - name: "rpm-build"
+      version: "4.14.3-32.0.1.1.al8"
+    - name: "rpm-libs"
+      version: "4.14.3-32.0.1.1.al8"
+    - name: "zlib"
+      version: "1.2.11-20.9.al8.alnx"
+    - name: "xz-libs"
+      version: "..."
+    - name: "libzstd"
+      version: "..."
+```
+
+Runner 会在安装完成后校验 buildspec 中声明了 `version` 的压缩工具链 RPM 包实际安装版本是否一致，并记录：
+
+```bash
+rpm --version
+rpm --showrc
+rpm -q rpm-build rpm-libs zlib xz-libs libzstd zstd
+```
+
+这些信息用于确认 RPM payload 压缩实现没有随镜像或仓库漂移。
+
 ### `tools`
 
 - 一个对象列表，每个对象包含工具的名称和版本。
@@ -256,8 +289,41 @@ outputs:
   - 检查指定路径的文件/目录是否存在
   - 如有 `sha256`，则计算文件哈希并与提供的值进行比较
   - 将输出文件/目录的信息记录到构建日志中，供后续流程使用
+  - 对 `.src.rpm` 输出读取 `PAYLOADCOMPRESSOR/PAYLOADFLAGS`，确认 GuanFu 内置的 RPM source payload 策略已生效
 
 在使用 `build-runner.sh` 脚本进行本地构建时，脚本会自动解析 `outputs` 部分，并将相应的目录挂载到容器中，确保构建产物能够正确地保存到宿主机上。
+
+---
+
+## GuanFu 内置 RPM source payload 策略
+
+GuanFu runner 内置 RPM source payload 策略：
+
+```rpm
+%_source_payload w9.gzdio
+```
+
+这表示 SRPM payload 使用 gzip level 9。构建完成后，Runner 会对声明在 `outputs` 中的 `.src.rpm` 执行：
+
+```bash
+rpm -qp --queryformat '%{PAYLOADCOMPRESSOR}\n%{PAYLOADFLAGS}\n' <src.rpm>
+```
+
+默认期望值为：
+
+```text
+PAYLOADCOMPRESSOR=gzip
+PAYLOADFLAGS=9
+```
+
+调试或灰度时可通过环境变量回退：
+
+```bash
+GUANFU_RPM_SOURCE_PAYLOAD=w.ufdio          # 使用近期无压缩 workaround
+GUANFU_RPM_SOURCE_PAYLOAD=system-default  # 不注入 %_source_payload，只记录实际值
+```
+
+`build-runner.sh` 会将宿主机上的 `GUANFU_RPM_SOURCE_PAYLOAD` 透传到构建容器中。
 
 ---
 

--- a/src/build-runner.sh
+++ b/src/build-runner.sh
@@ -134,6 +134,8 @@ if [ -n "$OUTPUT_PATHS" ]; then
     done <<< "$OUTPUT_PATHS"
 fi
 
+ENV_ARGS="-e GUANFU_RPM_SOURCE_PAYLOAD"
+
 # 获取BUILD_SPEC_FILE绝对路径
 [[ "$BUILD_SPEC_FILE" != /* ]] && BUILD_SPEC_FILE="$PWD/$BUILD_SPEC_FILE"
 
@@ -144,11 +146,12 @@ echo "  Running build in container: $CONTAINER_IMAGE"
 echo "  Build spec file: $BUILD_SPEC_FILE"
 echo "  Input mounts: $INPUT_MOUNTS"
 echo "  Output mounts: $OUTPUT_MOUNTS"
+echo "  Env args: $ENV_ARGS"
 echo "==========================================="
 
 # docker run --rm $OUTPUT_MOUNTS -v "$BUILD_SPEC_FILE:/opt/build-system/buildspec.yaml" -v "$SCRIPT_DIR:/opt/build-system/scripts" "$CONTAINER_IMAGE" \
 #     /bin/bash -c "cd /opt/build-system && python3 scripts/run_build.py buildspec.yaml"
-docker run --rm $INPUT_MOUNTS $OUTPUT_MOUNTS \
+docker run --rm $INPUT_MOUNTS $OUTPUT_MOUNTS $ENV_ARGS \
   -v "$BUILD_SPEC_FILE:/opt/build-system/buildspec.yaml" \
   -v "$SCRIPT_DIR:/opt/build-system/scripts" \
   "$CONTAINER_IMAGE" \

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -1,14 +1,35 @@
 #!/usr/bin/env python3
 import os
 import sys
+import re
+import hashlib
+import shutil
 import subprocess
 import urllib.parse
 import yaml
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Tuple
 
 # ----------------------
 # 通用工具函数
 # ----------------------
+
+DEFAULT_RPM_SOURCE_PAYLOAD = "w9.gzdio"
+SYSTEM_DEFAULT_RPM_SOURCE_PAYLOAD = "system-default"
+PAYLOAD_FLAG_RE = re.compile(r"^w([A-Za-z0-9+]*)\.(gzdio|bzdio|xzdio|lzdio|zstdio|ufdio)$")
+PAYLOAD_COMPRESSOR_BY_TYPE = {
+    "gzdio": "gzip",
+    "bzdio": "bzip2",
+    "xzdio": "xz",
+    "lzdio": "lzma",
+    "zstdio": "zstd",
+    "ufdio": "(none)",
+}
+RPM_TOOLCHAIN_PACKAGES = ["rpm-build", "rpm-libs", "zlib", "xz-libs", "libzstd", "zstd"]
+RPM_TOOLCHAIN_PACKAGE_NAMES = set(RPM_TOOLCHAIN_PACKAGES)
+
+
+class BuildRunnerError(RuntimeError):
+    pass
 
 
 def run(cmd: str, env: Optional[Dict[str, str]] = None) -> None:
@@ -32,6 +53,55 @@ def ensure_file(path: str) -> None:
 def load_spec(spec_path: str) -> Dict[str, Any]:
     with open(spec_path) as f:
         return yaml.safe_load(f)
+
+
+def _run_capture(cmd: List[str]) -> Tuple[int, str, str]:
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def validate_rpm_source_payload(value: str) -> str:
+    if value == SYSTEM_DEFAULT_RPM_SOURCE_PAYLOAD:
+        return value
+    match = PAYLOAD_FLAG_RE.match(value or "")
+    if not match:
+        raise BuildRunnerError(
+            "invalid GUANFU_RPM_SOURCE_PAYLOAD '%s'; expected '%s' or rpm payload flags like 'w9.gzdio'"
+            % (value, SYSTEM_DEFAULT_RPM_SOURCE_PAYLOAD)
+        )
+    flags, payload_type = match.groups()
+    if payload_type == "ufdio" and flags:
+        raise BuildRunnerError("invalid GUANFU_RPM_SOURCE_PAYLOAD '%s'; ufdio must not use compression flags" % value)
+    return value
+
+
+def rpm_source_payload_from_env() -> str:
+    value = os.environ.get("GUANFU_RPM_SOURCE_PAYLOAD", DEFAULT_RPM_SOURCE_PAYLOAD).strip()
+    if not value:
+        value = DEFAULT_RPM_SOURCE_PAYLOAD
+    return validate_rpm_source_payload(value)
+
+
+def expected_payload_header(payload: str) -> Optional[Tuple[str, str]]:
+    if payload == SYSTEM_DEFAULT_RPM_SOURCE_PAYLOAD:
+        return None
+    match = PAYLOAD_FLAG_RE.match(payload)
+    if not match:
+        raise BuildRunnerError("invalid rpm source payload '%s'" % payload)
+    flags, payload_type = match.groups()
+    return PAYLOAD_COMPRESSOR_BY_TYPE[payload_type], flags
+
+
+def build_rpm_macros_content(source_payload: str) -> str:
+    lines = [
+        "%build_mtime_policy clamp_to_source_date_epoch",
+        "%clamp_mtime_to_source_date_epoch 1",
+        "%use_source_date_epoch_as_buildtime 1",
+        "%_buildhost reproducible",
+    ]
+    if source_payload != SYSTEM_DEFAULT_RPM_SOURCE_PAYLOAD:
+        lines.append(f"%_source_payload {source_payload}")
+    return "\n".join(lines) + "\n"
 
 
 # ----------------------
@@ -84,21 +154,19 @@ def handle_inputs(spec: Dict[str, Any]) -> None:
 # 处理 environment（default + systemVariables + systemPackages + tools）
 # ----------------------
 
-def setup_default_environment() -> None:
+def setup_default_environment() -> str:
     # Set default environment variables
     os.environ['LANG'] = 'C.UTF-8'
     os.environ['LC_ALL'] = 'C.UTF-8'
     os.environ['TZ'] = 'UTC'
     os.environ['SOURCE_DATE_EPOCH'] = '1717020800'
     os.environ['RPM_BUILD_NCPUS'] = '1'
+
+    source_payload = rpm_source_payload_from_env()
+    print(f"[build-runner] RPM source payload policy: {source_payload}")
     
     # Setup RPM macros for reproducible builds
-    rpm_macros_content = """%build_mtime_policy clamp_to_source_date_epoch
-%clamp_mtime_to_source_date_epoch 1
-%use_source_date_epoch_as_buildtime 1
-%_buildhost reproducible
-%_source_payload w.ufdio
-"""
+    rpm_macros_content = build_rpm_macros_content(source_payload)
     with open('/etc/rpm/macros.buildroot', 'w') as f:
         f.write(rpm_macros_content)
     
@@ -181,6 +249,90 @@ debug = 1"""
     with open('/root/.cargo/config.toml', 'w') as f:
         f.write(rust_config_content)
 
+    return source_payload
+
+
+def _versioned_packages(items: List[Any]) -> List[Tuple[str, str]]:
+    packages = []
+    for item in items:
+        if isinstance(item, dict) and item.get("name") and item.get("version"):
+            packages.append((str(item["name"]), str(item["version"])))
+    return packages
+
+
+def declared_versioned_packages(spec: Dict[str, Any]) -> List[Tuple[str, str]]:
+    env_cfg = spec.get("environment", {}) or {}
+    packages = []
+    packages.extend(_versioned_packages(env_cfg.get("systemPackages", []) or []))
+    packages.extend(_versioned_packages(env_cfg.get("tools", []) or []))
+    return packages
+
+
+def _normalize_rpm_version_line(line: str) -> str:
+    epoch, sep, version_release = line.strip().partition(":")
+    if not sep:
+        return line.strip()
+    if epoch in ("", "(none)", "0"):
+        return version_release
+    return "%s:%s" % (epoch, version_release)
+
+
+def query_installed_rpm_versions(name: str) -> List[str]:
+    if not shutil.which("rpm"):
+        raise BuildRunnerError("rpm command is not available; cannot verify package '%s'" % name)
+    query = "%{EPOCH}:%{VERSION}-%{RELEASE}\n"
+    code, out, err = _run_capture(["rpm", "-q", "--qf", query, name])
+    if code != 0:
+        raise BuildRunnerError("failed to query package '%s': %s" % (name, err or out))
+    return [_normalize_rpm_version_line(line) for line in out.splitlines() if line.strip()]
+
+
+def verify_declared_package_versions(packages: List[Tuple[str, str]]) -> None:
+    packages = [(name, version) for name, version in packages if name in RPM_TOOLCHAIN_PACKAGE_NAMES]
+    if not packages:
+        return
+    if not shutil.which("rpm"):
+        print("[build-runner] WARNING: rpm is not available; skipping declared package version verification")
+        return
+
+    print("[build-runner] Verifying declared package versions...")
+    for name, expected in packages:
+        versions = query_installed_rpm_versions(name)
+        if expected not in versions:
+            raise BuildRunnerError(
+                "package '%s' version mismatch: expected %s, installed %s"
+                % (name, expected, ", ".join(versions) or "<not installed>")
+            )
+        print(f"[build-runner]  - {name}: {expected} OK")
+
+
+def log_rpm_toolchain_state() -> None:
+    if not shutil.which("rpm"):
+        print("[build-runner] WARNING: rpm is not available; skipping rpm toolchain state logging")
+        return
+
+    print("[build-runner] RPM toolchain state:")
+    code, out, err = _run_capture(["rpm", "--version"])
+    if code == 0:
+        print(f"[build-runner]  - {out}")
+    else:
+        print(f"[build-runner]  - rpm --version failed: {err or out}")
+
+    code, out, err = _run_capture(["rpm", "--showrc"])
+    if code == 0:
+        digest = hashlib.sha256(out.encode("utf-8")).hexdigest()
+        print(f"[build-runner]  - rpm --showrc sha256: {digest}")
+    else:
+        print(f"[build-runner]  - rpm --showrc failed: {err or out}")
+
+    code, out, err = _run_capture(["rpm", "-q"] + RPM_TOOLCHAIN_PACKAGES)
+    if out:
+        for line in out.splitlines():
+            print(f"[build-runner]  - {line}")
+    if code != 0 and err:
+        for line in err.splitlines():
+            print(f"[build-runner]  - {line}")
+
 def handle_environment(spec: Dict[str, Any], os_runner: OsRunnerBase) -> None:
     env_cfg = spec.get("environment", {}) or {}
     system_packages = env_cfg.get("systemPackages", []) or []
@@ -223,6 +375,9 @@ def handle_environment(spec: Dict[str, Any], os_runner: OsRunnerBase) -> None:
                     tool_list.append(tool['name'])
         os_runner.install_system_packages(tool_list)
 
+    log_rpm_toolchain_state()
+    verify_declared_package_versions(declared_versioned_packages(spec))
+
 
 # ----------------------
 # 处理 phases
@@ -238,6 +393,53 @@ def handle_phases(spec: Dict[str, Any]) -> None:
         commands = phase.get("commands", []) or []
         for cmd in commands:
             run(cmd)
+
+
+def _source_rpm_outputs(spec: Dict[str, Any]) -> List[str]:
+    outputs = spec.get("outputs", []) or []
+    paths = []
+    for output in outputs:
+        if isinstance(output, dict):
+            path = output.get("path")
+            if isinstance(path, str) and path.endswith(".src.rpm"):
+                paths.append(path)
+    return paths
+
+
+def query_source_rpm_payload_header(path: str) -> Tuple[str, str]:
+    query = "%{PAYLOADCOMPRESSOR}\n%{PAYLOADFLAGS}\n"
+    code, out, err = _run_capture(["rpm", "-qp", "--queryformat", query, path])
+    if code != 0:
+        raise BuildRunnerError("failed to query source rpm payload for '%s': %s" % (path, err or out))
+    lines = out.splitlines()
+    compressor = lines[0].strip() if len(lines) >= 1 else ""
+    flags = lines[1].strip() if len(lines) >= 2 else ""
+    if flags == "(none)":
+        flags = ""
+    return compressor, flags
+
+
+def verify_source_payload_outputs(spec: Dict[str, Any], source_payload: str) -> None:
+    source_rpms = _source_rpm_outputs(spec)
+    if not source_rpms:
+        print("[build-runner] WARNING: no .src.rpm output declared; skipping source payload verification")
+        return
+
+    expected = expected_payload_header(source_payload)
+    for path in source_rpms:
+        actual = query_source_rpm_payload_header(path)
+        print(
+            "[build-runner] Source RPM payload for %s: PAYLOADCOMPRESSOR=%s, PAYLOADFLAGS=%s"
+            % (path, actual[0], actual[1])
+        )
+        if expected is None:
+            continue
+        if actual != expected:
+            raise BuildRunnerError(
+                "source rpm payload mismatch for '%s': expected PAYLOADCOMPRESSOR=%s, PAYLOADFLAGS=%s; "
+                "got PAYLOADCOMPRESSOR=%s, PAYLOADFLAGS=%s"
+                % (path, expected[0], expected[1], actual[0], actual[1])
+            )
 
 
 # ----------------------
@@ -257,7 +459,7 @@ def main():
     handle_inputs(spec)
     
     # 2-1. 配置默认的环境参数
-    setup_default_environment()
+    source_payload = setup_default_environment()
 
     # 2-2. 根据 environment 安装系统包和工具
     handle_environment(spec, os_runner)
@@ -265,7 +467,13 @@ def main():
     # 3. 执行 phases
     handle_phases(spec)
 
+    # 4. 校验 source rpm payload 策略是否生效
+    verify_source_payload_outputs(spec, source_payload)
+
 
 if __name__ == "__main__":
-    main()
-
+    try:
+        main()
+    except BuildRunnerError as exc:
+        print(f"[build-runner] ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import run_build  # noqa: E402
+
+
+class RunBuildPayloadTests(unittest.TestCase):
+    def test_default_source_payload_is_gzip9(self):
+        with patch.dict(os.environ, {}, clear=True):
+            payload = run_build.rpm_source_payload_from_env()
+
+        self.assertEqual(payload, "w9.gzdio")
+        self.assertIn("%_source_payload w9.gzdio", run_build.build_rpm_macros_content(payload))
+        self.assertEqual(run_build.expected_payload_header(payload), ("gzip", "9"))
+
+    def test_source_payload_can_use_ufdio_escape_hatch(self):
+        with patch.dict(os.environ, {"GUANFU_RPM_SOURCE_PAYLOAD": "w.ufdio"}, clear=True):
+            payload = run_build.rpm_source_payload_from_env()
+
+        self.assertEqual(payload, "w.ufdio")
+        self.assertIn("%_source_payload w.ufdio", run_build.build_rpm_macros_content(payload))
+        self.assertEqual(run_build.expected_payload_header(payload), ("(none)", ""))
+
+    def test_source_payload_can_use_system_default(self):
+        with patch.dict(os.environ, {"GUANFU_RPM_SOURCE_PAYLOAD": "system-default"}, clear=True):
+            payload = run_build.rpm_source_payload_from_env()
+
+        self.assertEqual(payload, "system-default")
+        self.assertNotIn("%_source_payload", run_build.build_rpm_macros_content(payload))
+        self.assertIsNone(run_build.expected_payload_header(payload))
+
+    def test_invalid_source_payload_fails(self):
+        with self.assertRaises(run_build.BuildRunnerError):
+            run_build.validate_rpm_source_payload("gzip-9")
+
+    def test_ufdio_rejects_compression_flags(self):
+        with self.assertRaises(run_build.BuildRunnerError):
+            run_build.validate_rpm_source_payload("w9.ufdio")
+
+    def test_verify_source_payload_accepts_matching_header(self):
+        spec = {"outputs": [{"path": "/tmp/pkg.src.rpm"}]}
+        with patch.object(run_build, "query_source_rpm_payload_header", return_value=("gzip", "9")):
+            run_build.verify_source_payload_outputs(spec, "w9.gzdio")
+
+    def test_verify_source_payload_rejects_mismatched_header(self):
+        spec = {"outputs": [{"path": "/tmp/pkg.src.rpm"}]}
+        with patch.object(run_build, "query_source_rpm_payload_header", return_value=("(none)", "")):
+            with self.assertRaises(run_build.BuildRunnerError):
+                run_build.verify_source_payload_outputs(spec, "w9.gzdio")
+
+    def test_verify_source_payload_skips_strong_check_for_system_default(self):
+        spec = {"outputs": [{"path": "/tmp/pkg.src.rpm"}]}
+        with patch.object(run_build, "query_source_rpm_payload_header", return_value=("xz", "2")):
+            run_build.verify_source_payload_outputs(spec, "system-default")
+
+    def test_declared_versioned_packages_collects_system_packages_and_tools(self):
+        spec = {
+            "environment": {
+                "systemPackages": [{"name": "rpm-build", "version": "4.14.3-32.al8"}],
+                "tools": [{"name": "clang", "version": "15.0.7-1.al8"}],
+            }
+        }
+
+        self.assertEqual(
+            run_build.declared_versioned_packages(spec),
+            [("rpm-build", "4.14.3-32.al8"), ("clang", "15.0.7-1.al8")],
+        )
+
+    def test_declared_package_version_mismatch_fails(self):
+        with patch.object(run_build.shutil, "which", return_value="/usr/bin/rpm"):
+            with patch.object(run_build, "query_installed_rpm_versions", return_value=["1.0-1"]):
+                with self.assertRaises(run_build.BuildRunnerError):
+                    run_build.verify_declared_package_versions([("zlib", "1.0-2")])
+
+    def test_declared_non_toolchain_package_versions_are_not_strictly_verified(self):
+        with patch.object(run_build.shutil, "which", return_value="/usr/bin/rpm"):
+            with patch.object(run_build, "query_installed_rpm_versions") as query:
+                run_build.verify_declared_package_versions([("openssl-devel", "1.1.1k")])
+
+        query.assert_not_called()
+
+    def test_normalize_rpm_version_strips_absent_epoch(self):
+        self.assertEqual(run_build._normalize_rpm_version_line("(none):1.2.11-20.al8"), "1.2.11-20.al8")
+        self.assertEqual(run_build._normalize_rpm_version_line("0:1.2.11-20.al8"), "1.2.11-20.al8")
+        self.assertEqual(run_build._normalize_rpm_version_line("2:1.30-11.al8"), "2:1.30-11.al8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Change GuanFu's built-in RPM source payload policy to deterministic gzip level 9 (w9.gzdio).
- Add GUANFU_RPM_SOURCE_PAYLOAD escape hatches for w.ufdio and system-default.
- Verify declared .src.rpm outputs use the active source payload policy and log RPM compression toolchain state.
- Document the built-in source payload behavior and package pinning recommendation.

## Validation

- PYTHONPATH=src python3 -m pytest tests -> 42 passed
- bash -n src/build-runner.sh
- Real cryptpilot rebuild produced gzip/9 SRPM payload and matched available historical RPM full sha256 values.